### PR TITLE
fix(native-teams): migrate playbook off removed TeamCreate/TeamDelete (CC 2.1.178+)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ data/*.db
 data/*.db-journal
 data/*.db-wal
 data/*.db-shm
+
+# Observer hook failure log (runtime telemetry, not source)
+.ateam-observer-failures.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ work_log:                                   # Populated by agentStop
     summary: "Created 5 test cases"
 ```
 
-The `outputs` field is critical - without it, Murdock and B.A. don't know where to create files.
+The `outputs` field is critical - without it, Murdock and B.A. don't know where to create files. On the `ateam items createItem` command line, the outputs are set with **dotted** flags — `--outputs.test`, `--outputs.impl`, `--outputs.types` (NOT `--outputTest` or `--output-test`; the CLI rejects those with `Error: unknown flag`). `--outputs.types` is optional. **Create items one at a time** (one sequential `Bash` call each), never several `createItem` calls batched into a single parallel tool block — if the first call errors, the harness cancels the rest of the batch and burns item IDs.
 
 **All four text fields are required** when creating work items via `ateam items createItem`:
 - **`description`**: Human-readable executive summary — synthesizes objective + context into 1-3 sentences a PM could skim on the kanban board. Not a dump of structured data; a prose narrative of the work item.

--- a/adr/0001-token-usage-accounting.md
+++ b/adr/0001-token-usage-accounting.md
@@ -1,0 +1,130 @@
+# ADR 0001: Token Usage Accounting
+
+**Status:** Accepted
+**Date:** 2026-06-28
+**Deciders:** Josh + Claude
+
+## Context
+
+The A(i)-Team reports per-agent, per-model token cost for every mission (the
+kanban-viewer dashboard, `MissionTokenUsage`). Getting this number *right* turned
+out to be subtle: across one long debugging session we found **five distinct
+ways the pipeline mis-counted tokens**, several of which masked or inverted each
+other so the dashboard total was confidently wrong. This ADR records how token
+accounting is supposed to work and every trap we hit, so we don't re-learn them.
+
+The single hardest lesson: **every counting bug here was found by checking raw
+data, and every bug we "diagnosed by reasoning" without checking was wrong at
+least once.** Verify against transcripts/DB, never infer.
+
+## The pipeline
+
+```
+Claude Code transcript (.jsonl)          ← ground truth: per-message usage deltas
+        │  observer hooks (Stop / SubagentStop)
+        ▼  scripts/hooks/lib/parse-transcript.js   ← parse + dedup per message
+HookEvent rows (per stop/subagent_stop)  ← captured token totals per agent event
+        │  POST /api/missions/:id/token-usage
+        ▼  packages/kanban-viewer/.../token-usage/route.ts   ← aggregate
+MissionTokenUsage rows (per agent+model) ← derived rollup the dashboard reads
+        │  calculateTokenCost (token-cost.ts + ateam.config.json pricing)
+        ▼
+$ per agent, $ per mission
+```
+
+## How token usage is calculated (the rules)
+
+### 1. Transcript usage is a per-message DELTA, not a cumulative total
+Each assistant message's `usage` block is that message's own consumption. To get
+a session total you **sum across messages**. (Verified empirically: cache-creation
+fluctuates per message — 30500 → 12089 → 5259 → … — it does not monotonically
+grow, so it is not cumulative.)
+
+### 2. Claude Code writes each message to the transcript MULTIPLE times
+As a message streams and then finalizes, the same `message.id` is written 2–3×,
+each emission carrying the same final usage. **You must dedup by `message.id`**
+before summing, or you over-count by the duplication factor (measured **2.6×–3.4×**
+across real transcripts). `parse-transcript.js` keys usage by `message.id`
+(last-write-wins per id) and sums the deduped values. Lines with no `message.id`
+cannot be deduped and are summed as-is (assumed distinct).
+
+### 3. `stop` vs `subagent_stop` events mean different things
+- **`subagent_stop`** — fired when a subagent (spawned via `Agent`/Task) finishes.
+  One per subagent process. Its token total is that subagent's whole run.
+  **SUM across events**, because distinct subagent processes (incl. pool
+  instances murdock-1, murdock-2 …) are independent.
+- **`stop`** — fired by a top-level session every turn, carrying the session's
+  **cumulative** total. **Take only the latest per (agent, model)** — summing
+  multiple stop events massively over-counts (each is a growing snapshot).
+
+### 4. Only genuine top-level sessions own `stop` events
+`hannibal` (the orchestrator) and native teammates that emit *only* `stop` are
+real session owners. Subagents that run inside the main context (`face`, `sosa`,
+`stockwell`, `retro`, `tawnia`) report real work via `subagent_stop` **and** emit
+a *phantom* `stop` carrying the main session's cumulative total tagged with their
+name (often on a different model than their real work). **If a base role appears
+in `subagent_stop` at all, drop ALL its `stop` events.**
+
+### 5. Pool instances roll up to their base role
+`murdock-1`, `murdock-2`, … are instances of one logical agent. Group by
+`baseAgentName()` (strip a trailing `-<digits>`). Sum independent instances; do
+not collapse cumulative snapshots of one instance (handled by rule 3).
+
+### 6. Pricing
+`calculateTokenCost` (token-cost.ts) prices each (agent, model) at its model's
+rate: input and **cache-creation** at the input rate, **cache-read** at the
+discounted rate. Pricing comes from `ateam.config.json` `pricing` block, falling
+back to `DEFAULT_PRICING` in token-cost.ts. **Both must list every current model**
+— a missing model silently falls back to the Sonnet rate.
+
+### 7. Re-aggregation is idempotent
+POST deletes the mission's existing `MissionTokenUsage` rows before writing, so
+re-running after a logic change never leaves stale rows.
+
+## Trials we hit (the bugs, in the order found)
+
+| # | Bug | Symptom | Root cause | Fix |
+|---|-----|---------|-----------|-----|
+| 1 | **Opus priced as Sonnet** | opus agents ~1.67× under-reported | opus-4-7/4-8 missing from pricing config *and* `DEFAULT_PRICING`; container reads kanban-viewer's own minimal `ateam.config.json` (no pricing block) | add opus-4-7/4-8 to `DEFAULT_PRICING` |
+| 2 | **Cross-model `stop` double-count** | hannibal ~2× (two rows summed) | aggregation kept latest stop *per (agent, model)* then summed across models; one drifting session became two near-full snapshots | take single latest stop per agent for session owners |
+| 3 | **Agent-variant fragmentation** | murdock split across murdock-1..N | grouped by exact name | `baseAgentName()` rollup |
+| 4 | **Phantom main-session bleed-through** | retro/tawnia/stockwell each +~$18 (a copy of hannibal's total) | subagents emit a `stop` carrying the main-session cumulative on a different model; per-(role,model) skip missed it | drop ALL stop events for any role seen in `subagent_stop` |
+| 5 | **Duplicate-message summing** | every agent inflated 2.6–3.4×; e.g. one Face pass showed 12.4M cache-creation | `parse-transcript.js` summed every transcript line; Claude Code writes each message 2–3× | dedup by `message.id` |
+
+### Confounds that made this hard
+- Bugs **canceled out**: opus under-pricing (#1, too low) partly masked the
+  stop double-count (#2, too high), so a wrong total looked plausible.
+- The fixes were **committed to main but not live** for weeks because the
+  kanban-viewer **Docker container was never rebuilt** — and when rebuilt, it
+  failed (relative `DATABASE_URL` + Prisma 7/libSQL → empty DB → seed crash;
+  fixed with an absolute build-time `DATABASE_URL`).
+- Two different `ateam.config.json` files exist (plugin root vs kanban-viewer);
+  the container reads the latter, so a pricing fix to the former did nothing.
+
+## Decision
+
+Adopt rules 1–7 above as the canonical token-accounting model. Encode each in a
+regression test. The medium-term target (see
+`prd/drafts/accurate-token-attribution.md`) is a per-message `MessageTokenUsage`
+store keyed by `message.id`, which makes rules 2–5 structural rather than
+heuristic — at that point much of the aggregation special-casing can be deleted.
+
+## Validation
+
+Canonical fixture: mission `M-test-harness-20260628-002`. Hand-computed from raw
+events = **$35.51**; dashboard after fixes #1–4 = **$35.53** (rounding). Fix #5
+(message dedup) is verified by `parse-transcript.test.ts` and reduces raw
+transcript token counts by the measured 2.6–3.4× duplication factor; it affects
+runs captured *after* the fix (historical HookEvent rows were captured pre-dedup
+and cannot be retroactively corrected without re-parsing transcripts, which may
+no longer exist — see "forward-only" in the attribution PRD).
+
+## Consequences
+
+- Historical `MissionTokenUsage` for runs captured before fix #5 remains inflated
+  ~2.6–3.4× on cache tokens; do not compare pre- and post-fix runs on absolute
+  cost. Re-aggregation (POST) re-derives from HookEvent rows but cannot undo
+  capture-time over-counting.
+- Every rule above has a test; changing aggregation requires updating tests.
+- The dashboard is now authoritative for runs captured after these fixes; we no
+  longer hand-compute from raw events to trust a number.

--- a/agents/face.md
+++ b/agents/face.md
@@ -1,6 +1,7 @@
 ---
 name: face
 model: opus
+effort: medium
 description: Decomposer - breaks PRDs into work items
 skills:
   - ateam-cli
@@ -108,9 +109,11 @@ ateam items createItem \
   --acceptance "Running 'pnpm test' executes vitest with zero tests passing" \
   --acceptance "vitest.config.ts exists and resolves src/ paths" \
   --context "No existing test infrastructure. This is a Wave 0 dependency for all items with outputs.test." \
-  --outputImpl "vitest.config.ts" \
+  --outputs.impl "vitest.config.ts" \
   --priority critical
 ```
+
+**Output flags are dotted, not camelCase:** `--outputs.test`, `--outputs.impl`, `--outputs.types`. Do NOT write `--outputImpl`, `--outputTest`, or `--output-test` — the CLI rejects them with `Error: unknown flag`.
 
 Then reference its ID in dependencies for items that need tests.
 
@@ -173,9 +176,11 @@ Murdock (tests) → B.A. (implements) → Lynch (reviews all together)
 ```
 
 The outputs field tells each agent what to create:
-- Murdock creates `outputs.test` (and `outputs.types` if specified)
-- B.A. creates `outputs.impl`
+- Murdock creates `outputs.test` (and `outputs.types` if specified) — set on the CLI with `--outputs.test` / `--outputs.types`
+- B.A. creates `outputs.impl` — set on the CLI with `--outputs.impl`
 - Lynch reviews all files together
+
+The CLI flags are **dotted** (`--outputs.test`, `--outputs.impl`, `--outputs.types`), NOT camelCase (`--outputTest`) or kebab-case (`--output-test`). Wrong forms are rejected with `Error: unknown flag`.
 
 ## ID Convention
 
@@ -184,6 +189,8 @@ The outputs field tells each agent what to create:
 ## Creating Work Items
 
 **CRITICAL: Use `ateam items createItem` to create all work items.** Consult the `ateam-cli` skill for full flag reference.
+
+**Create items one at a time — never batch.** Issue each `ateam items createItem` as its own sequential `Bash` call. Wait for it to succeed, capture the returned ID, then create the next. Do **NOT** put several `createItem` calls into a single parallel tool block: if the first call errors (e.g. a mistyped flag), the harness cancels every other call in that block, turning one typo into a mass failure and burning item IDs (leaving gaps in the WI-XXX sequence). One bad flag should cost you one retry, not the whole decomposition.
 
 **Create items in dependency order:**
 1. First, create all items with NO dependencies (Wave 0)

--- a/agents/murdock.md
+++ b/agents/murdock.md
@@ -1,6 +1,7 @@
 ---
 name: murdock
 model: opus
+effort: low
 description: QA Engineer - writes tests before implementation
 permissionMode: acceptEdits
 skills:

--- a/agents/sosa.md
+++ b/agents/sosa.md
@@ -1,6 +1,7 @@
 ---
 name: sosa
 model: opus
+effort: medium
 description: Requirements Critic - reviews decomposition before execution
 skills:
   - ateam-cli

--- a/agents/stockwell.md
+++ b/agents/stockwell.md
@@ -1,6 +1,7 @@
 ---
 name: stockwell
 model: opus
+effort: medium
 description: Reviewer - Final Mission Review (holistic codebase review)
 skills:
   - test-writing

--- a/ateam.config.json
+++ b/ateam.config.json
@@ -16,6 +16,16 @@
   },
   "pricing": {
     "models": {
+      "claude-opus-4-8": {
+        "input_per_1m": 5.00,
+        "output_per_1m": 25.00,
+        "cache_read_per_1m": 0.50
+      },
+      "claude-opus-4-7": {
+        "input_per_1m": 5.00,
+        "output_per_1m": 25.00,
+        "cache_read_per_1m": 0.50
+      },
       "claude-opus-4-6": {
         "input_per_1m": 15.00,
         "output_per_1m": 75.00,

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -147,7 +147,7 @@ This command:
 ### 3. Invoke Face - First Pass
 
 ```
-Task(
+Agent(
   subagent_type: "ai-team:face",
   prompt: "You are Face from the A(i)-Team. [full face.md prompt]
 
@@ -177,7 +177,7 @@ If validation fails, report errors and stop.
 ### 5. Invoke Sosa (skip with --skip-refinement)
 
 ```
-Task(
+Agent(
   subagent_type: "ai-team:sosa",
   prompt: "You are Sosa from the A(i)-Team. [full sosa.md prompt]
 
@@ -206,7 +206,7 @@ Sosa will:
 ### 6. Invoke Face - Second Pass (skip with --skip-refinement)
 
 ```
-Task(
+Agent(
   subagent_type: "ai-team:face",
   prompt: "You are Face from the A(i)-Team. [full face.md prompt]
 

--- a/commands/resume.md
+++ b/commands/resume.md
@@ -210,7 +210,7 @@ Main Claude (as Hannibal)
     └── subagent → Tawnia (documentation)
 ```
 
-The dispatch mode (legacy Task/TaskOutput vs. native TeamCreate/SendMessage) is determined by the orchestration playbook loaded in step 4.
+The dispatch mode (legacy Task/TaskOutput vs. native Agent/SendMessage) is determined by the orchestration playbook loaded in step 4.
 
 ## CLI Commands Used
 

--- a/commands/run.md
+++ b/commands/run.md
@@ -427,7 +427,7 @@ This flat structure:
 - Allows mid-run intervention
 - Avoids nested subagent memory overhead
 
-The dispatch mode (legacy Task/TaskOutput vs. native TeamCreate/SendMessage) is determined by the orchestration playbook loaded in step 3.
+The dispatch mode (legacy Task/TaskOutput vs. native Agent/SendMessage) is determined by the orchestration playbook loaded in step 3.
 
 ## CLI Commands Used
 

--- a/packages/kanban-viewer/Dockerfile
+++ b/packages/kanban-viewer/Dockerfile
@@ -30,7 +30,14 @@ COPY packages/kanban-viewer/ .
 # Seed the database into data.init/ — this is the factory-fresh DB baked into
 # the image. At runtime the entrypoint copies it to the volume mount path on
 # first boot so users get stages pre-configured without needing prisma at runtime.
-ENV DATABASE_URL="file:./prisma/data.init/ateam.db"
+#
+# DATABASE_URL must be ABSOLUTE here. With Prisma 7 + the libSQL config,
+# `prisma migrate deploy` resolves a relative `file:` path against a different
+# base than the adapter connection, so a relative URL silently reports
+# "No pending migrations to apply" and writes an empty DB — seed then fails
+# with "no such table: main.Project". An absolute path makes migrate and seed
+# agree on the same physical file.
+ENV DATABASE_URL="file:/app/prisma/data.init/ateam.db"
 RUN mkdir -p prisma/data.init && \
     npx prisma generate && \
     npx prisma migrate deploy --config ./prisma/prisma.config.ts && \

--- a/packages/kanban-viewer/src/__tests__/agent-name.test.ts
+++ b/packages/kanban-viewer/src/__tests__/agent-name.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { baseAgentName } from '@/lib/agent-name';
+
+describe('baseAgentName', () => {
+  it('strips a trailing numeric instance suffix', () => {
+    expect(baseAgentName('murdock-1')).toBe('murdock');
+    expect(baseAgentName('murdock-2')).toBe('murdock');
+    expect(baseAgentName('ba-13')).toBe('ba');
+    expect(baseAgentName('lynch-0')).toBe('lynch');
+  });
+
+  it('leaves base role names without a suffix unchanged', () => {
+    for (const name of ['hannibal', 'face', 'sosa', 'murdock', 'ba', 'lynch', 'amy', 'stockwell', 'tawnia', 'retro']) {
+      expect(baseAgentName(name)).toBe(name);
+    }
+  });
+
+  it('does not strip non-numeric suffixes', () => {
+    expect(baseAgentName('ba')).toBe('ba');
+    expect(baseAgentName('amy-probe')).toBe('amy-probe');
+  });
+
+  it('only strips the last numeric segment', () => {
+    expect(baseAgentName('claude-4-6')).toBe('claude-4');
+  });
+});

--- a/packages/kanban-viewer/src/__tests__/hooks-events-api.test.ts
+++ b/packages/kanban-viewer/src/__tests__/hooks-events-api.test.ts
@@ -463,4 +463,81 @@ describe('POST /api/hooks/events', () => {
     expect(data.error.code).toBe('VALIDATION_ERROR');
     expect(data.error.message).toMatch(/batch|limit|100/i);
   });
+
+  /**
+   * FIX 1: Stop-event dedup via per-turn-stable correlationId.
+   *
+   * observe-stop.js sets correlationId = `${session_id}:${lastAssistantMessageId}`,
+   * which is identical across retries of the same turn's stop but distinct
+   * across different turns. The route must:
+   *   (a) collapse retries of the SAME stop into ONE row, keeping the LATEST
+   *       (largest) cumulative token totals (upsert, not skip-first), and
+   *   (b) store DIFFERENT turns' stops as SEPARATE rows (never collapse).
+   */
+  describe('stop-event dedup (FIX 1)', () => {
+    function stopEvent(correlationId: string, outputTokens: number, inputTokens: number) {
+      return {
+        eventType: 'stop',
+        agentName: 'hannibal',
+        status: 'stopped',
+        summary: 'hannibal stopped',
+        timestamp: new Date().toISOString(),
+        correlationId,
+        model: 'claude-sonnet-4-6',
+        inputTokens,
+        outputTokens,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+      };
+    }
+
+    async function post(body: unknown) {
+      const request = new NextRequest('http://localhost:3000/api/hooks/events', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Project-ID': 'test-project' },
+        body: JSON.stringify(body),
+      });
+      const response = await POST(request);
+      return response.json();
+    }
+
+    it('(a) two retries of the SAME stop → ONE row, keeping the latest token totals', async () => {
+      const correlationId = 'sess-A:msg_turn1';
+
+      // First send (e.g. network glitch caused a retry) with smaller cumulative totals.
+      await post(stopEvent(correlationId, 100, 1000));
+      // Retry of the SAME turn's stop, carrying NEWER (larger) cumulative totals.
+      const retry = await post(stopEvent(correlationId, 175, 1800));
+
+      // Retry is reported as skipped-create (it was an upsert of the existing row).
+      expect(retry.data.created).toBe(0);
+      expect(retry.data.skipped).toBe(1);
+
+      const rows = await prisma.hookEvent.findMany({
+        where: { projectId: 'test-project', eventType: 'stop', correlationId },
+      });
+      expect(rows).toHaveLength(1); // collapsed to a single row
+      // Latest values win — NOT the stale first-write values.
+      expect(rows[0].outputTokens).toBe(175);
+      expect(rows[0].inputTokens).toBe(1800);
+    });
+
+    it('(b) two DIFFERENT turns’ stops → TWO rows (not collapsed)', async () => {
+      const turn1 = await post(stopEvent('sess-A:msg_turn1', 100, 1000));
+      const turn2 = await post(stopEvent('sess-A:msg_turn2', 250, 2500));
+
+      expect(turn1.data.id ?? turn1.data.created).toBeTruthy();
+      expect(turn2.data.id ?? turn2.data.created).toBeTruthy();
+
+      const rows = await prisma.hookEvent.findMany({
+        where: { projectId: 'test-project', eventType: 'stop' },
+        orderBy: { outputTokens: 'asc' },
+      });
+      expect(rows).toHaveLength(2); // per-turn stops remain distinct
+      expect(rows.map((r) => r.correlationId).sort()).toEqual([
+        'sess-A:msg_turn1',
+        'sess-A:msg_turn2',
+      ]);
+    });
+  });
 });

--- a/packages/kanban-viewer/src/__tests__/token-aggregation.test.ts
+++ b/packages/kanban-viewer/src/__tests__/token-aggregation.test.ts
@@ -701,6 +701,183 @@ describe('POST /api/missions/:missionId/token-usage - multiple agents and models
   });
 });
 
+describe('POST /api/missions/:missionId/token-usage - pool instance consolidation', () => {
+  it('should consolidate murdock + murdock-1 + murdock-2 subagent_stop events into one base-role row', async () => {
+    // Pipeline pool runs spawn instances named murdock, murdock-1, murdock-2.
+    // Each subagent_stop is an independent process → its tokens should be summed
+    // under the single base role "murdock", not fragmented across N rows.
+    const ts = new Date();
+    await prisma.hookEvent.createMany({
+      data: [
+        {
+          projectId: PROJECT_ID,
+          missionId: MISSION_ID,
+          eventType: 'subagent_stop',
+          agentName: 'murdock',
+          status: 'completed',
+          summary: 'murdock instance 0',
+          timestamp: new Date(ts.getTime()),
+          inputTokens: 1000,
+          outputTokens: 200,
+          cacheCreationTokens: 100,
+          cacheReadTokens: 500,
+          model: 'claude-sonnet-4-6',
+        },
+        {
+          projectId: PROJECT_ID,
+          missionId: MISSION_ID,
+          eventType: 'subagent_stop',
+          agentName: 'murdock-1',
+          status: 'completed',
+          summary: 'murdock instance 1',
+          timestamp: new Date(ts.getTime() + 1000),
+          inputTokens: 2000,
+          outputTokens: 300,
+          cacheCreationTokens: 200,
+          cacheReadTokens: 700,
+          model: 'claude-sonnet-4-6',
+        },
+        {
+          projectId: PROJECT_ID,
+          missionId: MISSION_ID,
+          eventType: 'subagent_stop',
+          agentName: 'murdock-2',
+          status: 'completed',
+          summary: 'murdock instance 2',
+          timestamp: new Date(ts.getTime() + 2000),
+          inputTokens: 3000,
+          outputTokens: 500,
+          cacheCreationTokens: 300,
+          cacheReadTokens: 800,
+          model: 'claude-sonnet-4-6',
+        },
+        // hannibal stop event — distinct role, must remain its own row
+        {
+          projectId: PROJECT_ID,
+          missionId: MISSION_ID,
+          eventType: 'stop',
+          agentName: 'hannibal',
+          status: 'stopped',
+          summary: 'hannibal stop',
+          timestamp: new Date(ts.getTime() + 3000),
+          inputTokens: 5000,
+          outputTokens: 1000,
+          cacheCreationTokens: 2000,
+          cacheReadTokens: 8000,
+          model: 'claude-opus-4-6',
+        },
+      ],
+    });
+
+    const response = await POST(makeRequest('POST'), routeParams);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+
+    const agents: Array<{
+      agentName: string;
+      model: string;
+      inputTokens: number;
+      outputTokens: number;
+      cacheCreationTokens: number;
+      cacheReadTokens: number;
+    }> = data.data.agents;
+
+    // Exactly one consolidated murdock row (not three instance rows)
+    const murdockRows = agents.filter((a) => a.agentName === 'murdock');
+    expect(murdockRows).toHaveLength(1);
+    // No raw instance names leak into the breakdown
+    expect(agents.some((a) => /-\d+$/.test(a.agentName))).toBe(false);
+
+    const murdock = murdockRows[0];
+    expect(murdock.model).toBe('claude-sonnet-4-6');
+    expect(murdock.inputTokens).toBe(6000);        // 1000 + 2000 + 3000
+    expect(murdock.outputTokens).toBe(1000);       // 200 + 300 + 500
+    expect(murdock.cacheCreationTokens).toBe(600); // 100 + 200 + 300
+    expect(murdock.cacheReadTokens).toBe(2000);    // 500 + 700 + 800
+
+    // Mission grand total preserved (murdock 6000 + hannibal 5000), no double-count
+    expect(data.data.totals.inputTokens).toBe(11000);
+    expect(data.data.totals.outputTokens).toBe(2000);
+
+    // Persisted rows: one consolidated murdock row + one hannibal row
+    const persisted = await prisma.missionTokenUsage.findMany({ where: { missionId: MISSION_ID } });
+    expect(persisted).toHaveLength(2);
+    const persistedMurdock = persisted.filter((r) => r.agentName === 'murdock');
+    expect(persistedMurdock).toHaveLength(1);
+    expect(persistedMurdock[0].inputTokens).toBe(6000);
+  });
+
+  it('should sum distinct pool-instance stop events (native teammates) under one base role', async () => {
+    // Native teammate pool instances (amy, amy-1) each fire their own series of
+    // cumulative stop events. Within an instance we take the latest; across
+    // instances of the role we SUM (they are independent sessions).
+    const ts = new Date();
+    await prisma.hookEvent.createMany({
+      data: [
+        // amy instance 0 — two cumulative turns, latest is 3000
+        {
+          projectId: PROJECT_ID,
+          missionId: MISSION_ID,
+          eventType: 'stop',
+          agentName: 'amy',
+          status: 'stopped',
+          summary: 'amy turn 1',
+          timestamp: new Date(ts.getTime()),
+          inputTokens: 1500,
+          outputTokens: 200,
+          cacheCreationTokens: 0,
+          cacheReadTokens: 500,
+          model: 'claude-sonnet-4-6',
+        },
+        {
+          projectId: PROJECT_ID,
+          missionId: MISSION_ID,
+          eventType: 'stop',
+          agentName: 'amy',
+          status: 'stopped',
+          summary: 'amy turn 2 (cumulative)',
+          timestamp: new Date(ts.getTime() + 1000),
+          inputTokens: 3000,
+          outputTokens: 400,
+          cacheCreationTokens: 0,
+          cacheReadTokens: 1000,
+          model: 'claude-sonnet-4-6',
+        },
+        // amy instance 1 — single cumulative turn at 2000
+        {
+          projectId: PROJECT_ID,
+          missionId: MISSION_ID,
+          eventType: 'stop',
+          agentName: 'amy-1',
+          status: 'stopped',
+          summary: 'amy-1 final',
+          timestamp: new Date(ts.getTime() + 2000),
+          inputTokens: 2000,
+          outputTokens: 600,
+          cacheCreationTokens: 0,
+          cacheReadTokens: 800,
+          model: 'claude-sonnet-4-6',
+        },
+      ],
+    });
+
+    const response = await POST(makeRequest('POST'), routeParams);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const agents: Array<{ agentName: string; inputTokens: number; outputTokens: number }> = data.data.agents;
+
+    const amyRows = agents.filter((a) => a.agentName === 'amy');
+    expect(amyRows).toHaveLength(1);
+    // instance 0 latest (3000) + instance 1 (2000) = 5000; NOT 1500+3000+2000
+    expect(amyRows[0].inputTokens).toBe(5000);
+    expect(amyRows[0].outputTokens).toBe(1000); // 400 + 600
+    expect(data.data.totals.inputTokens).toBe(5000);
+  });
+});
+
 describe('POST /api/missions/:missionId/token-usage - excluded event warning', () => {
   it('should warn via console.warn when hook events are excluded due to missing token/model data', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/kanban-viewer/src/__tests__/token-aggregation.test.ts
+++ b/packages/kanban-viewer/src/__tests__/token-aggregation.test.ts
@@ -414,6 +414,77 @@ describe('POST /api/missions/:missionId/token-usage - double-counting prevention
     expect(murdock.inputTokens).toBe(1000);  // NOT 2000
     expect(murdock.outputTokens).toBe(500);  // NOT 1000
   });
+
+  it('should drop phantom main-session stop bleed-through on a subagent (different model)', async () => {
+    // Subagents that run inside the main context (retro, tawnia, stockwell) emit:
+    //   1. subagent_stop = their REAL work (e.g. retro on opus)
+    //   2. a phantom stop = the MAIN (hannibal) session cumulative total, tagged
+    //      with the subagent's name, on the MAIN session's model (sonnet)
+    // The phantom is a different model than the real work, so a per-(role,model)
+    // skip misses it. It must be dropped because the role already has
+    // subagent_stop data.
+    await prisma.hookEvent.createMany({
+      data: [
+        // retro's REAL work (opus subagent_stop)
+        {
+          projectId: PROJECT_ID,
+          missionId: MISSION_ID,
+          eventType: 'subagent_stop',
+          agentName: 'retro',
+          status: 'success',
+          summary: 'retro report',
+          timestamp: new Date(),
+          inputTokens: 6000,
+          outputTokens: 10000,
+          cacheCreationTokens: 100000,
+          cacheReadTokens: 1100000,
+          model: 'claude-opus-4-8',
+        },
+        // PHANTOM: main-session cumulative tagged as retro, on sonnet
+        {
+          projectId: PROJECT_ID,
+          missionId: MISSION_ID,
+          eventType: 'stop',
+          agentName: 'retro',
+          status: 'stopped',
+          summary: 'phantom main-session total',
+          timestamp: new Date(),
+          inputTokens: 2000,
+          outputTokens: 377000,
+          cacheCreationTokens: 800000,
+          cacheReadTokens: 29000000,
+          model: 'claude-sonnet-4-6',
+        },
+        // hannibal's real main-session stop (the true owner of that total)
+        {
+          projectId: PROJECT_ID,
+          missionId: MISSION_ID,
+          eventType: 'stop',
+          agentName: 'hannibal',
+          status: 'stopped',
+          summary: 'hannibal cumulative',
+          timestamp: new Date(),
+          inputTokens: 2000,
+          outputTokens: 377000,
+          cacheCreationTokens: 800000,
+          cacheReadTokens: 29000000,
+          model: 'claude-sonnet-4-6',
+        },
+      ],
+    });
+
+    const postData = await (await POST(makeRequest('POST'), routeParams)).json();
+    const rows = postData.data.agents.filter((a: { agentName: string }) => a.agentName === 'retro');
+
+    // retro must appear ONLY as its real opus subagent_stop work — no phantom sonnet row
+    expect(rows).toHaveLength(1);
+    expect(rows[0].model).toBe('claude-opus-4-8');
+    expect(rows[0].outputTokens).toBe(10000);   // real work, NOT the 377000 phantom
+    // hannibal still carries the real main-session total exactly once
+    const hannibal = postData.data.agents.filter((a: { agentName: string }) => a.agentName === 'hannibal');
+    expect(hannibal).toHaveLength(1);
+    expect(hannibal[0].outputTokens).toBe(377000);
+  });
 });
 
 describe('POST /api/missions/:missionId/token-usage - native teammate stop events', () => {

--- a/packages/kanban-viewer/src/app/api/hooks/events/route.ts
+++ b/packages/kanban-viewer/src/app/api/hooks/events/route.ts
@@ -279,8 +279,41 @@ export async function POST(
             err.message.includes('correlationId') &&
             err.message.includes('eventType');
           if (targetMatchesFields || messageMatchesFields) {
+            // For `stop` events the correlationId is per-turn-stable, so a
+            // duplicate is a NETWORK RETRY of the same turn's stop. Each retry
+            // may carry NEWER cumulative token totals, so we UPSERT — update the
+            // existing row to keep the latest values rather than skipping (which
+            // would freeze stale/smaller totals). The aggregation route keeps
+            // the latest stop per (agentName, model), so this yields one
+            // correct row per turn even across retries.
+            //
+            // All other event types use a random per-call correlationId, so a
+            // duplicate there is a true idempotent retry with identical data —
+            // skip-first preserves the original behavior and is harmless.
+            if (event.eventType === 'stop' && event.correlationId) {
+              await prisma.hookEvent.updateMany({
+                where: {
+                  correlationId: event.correlationId,
+                  eventType: event.eventType,
+                },
+                data: {
+                  agentName: event.agentName,
+                  toolName: event.toolName ?? null,
+                  status: event.status,
+                  durationMs: event.durationMs ?? null,
+                  summary: event.summary,
+                  payload: event.payload ?? '{}',
+                  timestamp: new Date(event.timestamp),
+                  inputTokens: event.inputTokens ?? null,
+                  outputTokens: event.outputTokens ?? null,
+                  cacheCreationTokens: event.cacheCreationTokens ?? null,
+                  cacheReadTokens: event.cacheReadTokens ?? null,
+                  model: event.model ?? null,
+                },
+              });
+            }
             skipped++;
-            continue; // Skip duplicate
+            continue; // Duplicate handled (upserted for stop, skipped otherwise)
           }
         }
         // Re-throw other errors

--- a/packages/kanban-viewer/src/app/api/missions/[missionId]/token-usage/route.ts
+++ b/packages/kanban-viewer/src/app/api/missions/[missionId]/token-usage/route.ts
@@ -168,6 +168,20 @@ export async function POST(request: Request, context: RouteContext) {
     // with identical token counts — using both would double-count).
     const keysFromSubagent = new Set<string>();
 
+    // Track which base ROLES ran as a subagent at all (any model). An agent that
+    // ran via the Task/Agent subagent mechanism (face, sosa, stockwell, retro,
+    // tawnia, ...) reports its real work via subagent_stop. It does NOT have its
+    // own top-level session, so any `stop` event bearing its name is the MAIN
+    // (hannibal) session's cumulative total bleeding through — these subagents
+    // finish inside the main context, and the main-session stop hook tags the
+    // cumulative total with whichever agent name was active. Those phantom stop
+    // rows (e.g. retro/tawnia/stockwell each carrying ~Hannibal's full total)
+    // must be dropped entirely, not just skipped per-(role,model): the phantom
+    // stop is sonnet while the real subagent_stop is opus, so a per-key skip
+    // misses it. Only genuine top-level sessions (hannibal, and native teammates
+    // that emit ONLY stop) should contribute stop-event cost.
+    const rolesFromSubagent = new Set<string>();
+
     function addToGroup(
       role: string,
       model: string,
@@ -199,6 +213,7 @@ export async function POST(request: Request, context: RouteContext) {
       const role = baseAgentName(event.agentName);
       const key = addToGroup(role, event.model!, event);
       keysFromSubagent.add(key);
+      rolesFromSubagent.add(role);
     }
 
     // Add latest stop events as FALLBACK. Each per-instance latest stop event is
@@ -213,6 +228,12 @@ export async function POST(request: Request, context: RouteContext) {
       if (keysFromSubagent.has(key)) {
         continue;
       }
+      // Drop phantom main-session bleed-through: if this role ran as a subagent
+      // (any model), its real cost is already counted via subagent_stop and any
+      // stop event under its name is the main-session cumulative total.
+      if (rolesFromSubagent.has(role)) {
+        continue;
+      }
       addToGroup(role, event.model!, event);
     }
 
@@ -220,6 +241,12 @@ export async function POST(request: Request, context: RouteContext) {
     const agents: AgentRow[] = [];
 
     await prisma.$transaction(async (tx) => {
+      // Clear prior rows for this mission first so re-aggregation is idempotent.
+      // Without this, re-running aggregation after the agent-variant consolidation
+      // change leaves stale per-instance rows (murdock-1, murdock-2, ...) alongside
+      // the new consolidated base-role row (murdock), double-listing the cost.
+      await tx.missionTokenUsage.deleteMany({ where: { missionId } });
+
       for (const group of groups.values()) {
         const { totalUsd } = calculateTokenCost(
           {

--- a/packages/kanban-viewer/src/app/api/missions/[missionId]/token-usage/route.ts
+++ b/packages/kanban-viewer/src/app/api/missions/[missionId]/token-usage/route.ts
@@ -9,6 +9,7 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { getAndValidateProjectId } from '@/lib/project-utils';
 import { calculateTokenCost } from '@/lib/token-cost';
+import { baseAgentName } from '@/lib/agent-name';
 import { createDatabaseError } from '@/lib/errors';
 import type { ApiError } from '@/types/api';
 
@@ -57,7 +58,14 @@ function sumTotals(agents: AgentRow[]): Totals {
  *   This prevents double-counting for legacy subagents (which have both event types)
  *   while correctly capturing native teammates (which only fire stop events).
  *
- * Groups by agentName+model, calculates cost, upserts MissionTokenUsage.
+ * Groups by base-role agentName+model, calculates cost, upserts MissionTokenUsage.
+ *
+ * Pool instances of one role (e.g. murdock, murdock-1, murdock-2) are
+ * consolidated into a single base-role row via `baseAgentName`, so the
+ * per-agent breakdown reads as one line per logical role rather than being
+ * fragmented across N instance rows. Normalization only changes how events
+ * are bucketed — every event is still counted exactly once, so the mission
+ * grand total is unchanged and never double-counted.
  */
 export async function POST(request: Request, context: RouteContext) {
   try {
@@ -115,7 +123,12 @@ export async function POST(request: Request, context: RouteContext) {
       orderBy: { id: 'desc' },
     });
 
-    // Keep only the latest stop event per agent+model
+    // Keep only the latest stop event per RAW instance agent+model.
+    // stop events report cumulative session-to-date totals, so within a single
+    // session/instance we take only the latest. We key by the raw agentName
+    // (NOT the base role) here because distinct pool instances (amy-1, amy-2)
+    // are independent sessions, each with its own cumulative total — those must
+    // be summed across instances when rolled into the base-role group below.
     const latestStopByKey = new Map<string, typeof stopEvents[number]>();
     for (const event of stopEvents) {
       const key = `${event.agentName}:${event.model}`;
@@ -146,11 +159,21 @@ export async function POST(request: Request, context: RouteContext) {
       );
     }
 
-    // Group subagent events by agentName+model (sum all)
+    // Group events by base-role agentName+model. Pool instances of one role
+    // (murdock, murdock-1, murdock-2, ...) consolidate into a single row.
     const groups = new Map<string, { agentName: string; model: string; inputTokens: number; outputTokens: number; cacheCreationTokens: number; cacheReadTokens: number }>();
 
-    for (const event of subagentEvents) {
-      const key = `${event.agentName}:${event.model}`;
+    // Track which base-role keys were populated from subagent_stop data so the
+    // stop-event fallback can skip them (legacy subagents fire BOTH event types
+    // with identical token counts — using both would double-count).
+    const keysFromSubagent = new Set<string>();
+
+    function addToGroup(
+      role: string,
+      model: string,
+      event: { inputTokens: number | null; outputTokens: number | null; cacheCreationTokens: number | null; cacheReadTokens: number | null }
+    ) {
+      const key = `${role}:${model}`;
       const existing = groups.get(key);
       if (existing) {
         existing.inputTokens += event.inputTokens ?? 0;
@@ -159,32 +182,38 @@ export async function POST(request: Request, context: RouteContext) {
         existing.cacheReadTokens += event.cacheReadTokens ?? 0;
       } else {
         groups.set(key, {
-          agentName: event.agentName,
-          model: event.model!,
+          agentName: role,
+          model,
           inputTokens: event.inputTokens ?? 0,
           outputTokens: event.outputTokens ?? 0,
           cacheCreationTokens: event.cacheCreationTokens ?? 0,
           cacheReadTokens: event.cacheReadTokens ?? 0,
         });
       }
+      return key;
     }
 
-    // Add latest stop events as FALLBACK only (no summing — each is already cumulative).
-    // Only populate if no subagent_stop data exists for this agent+model.
-    // This prevents double-counting for legacy subagents (which have both event types)
-    // while correctly capturing native teammates and hannibal (which only fire stop).
+    // subagent_stop events are independent (one per subagent process) → sum all,
+    // consolidating pool instances into their base role.
+    for (const event of subagentEvents) {
+      const role = baseAgentName(event.agentName);
+      const key = addToGroup(role, event.model!, event);
+      keysFromSubagent.add(key);
+    }
+
+    // Add latest stop events as FALLBACK. Each per-instance latest stop event is
+    // already cumulative for that session, so we SUM the per-instance latests
+    // across pool instances of a role (amy-1 + amy-2 are distinct sessions), but
+    // NOT across turns of one instance (dedup handled in latestStopByKey above).
+    // Skip a role entirely if subagent_stop already populated it — that prevents
+    // double-counting legacy subagents that fire both event types.
     for (const event of latestStopByKey.values()) {
-      const key = `${event.agentName}:${event.model}`;
-      if (!groups.has(key)) {
-        groups.set(key, {
-          agentName: event.agentName,
-          model: event.model!,
-          inputTokens: event.inputTokens ?? 0,
-          outputTokens: event.outputTokens ?? 0,
-          cacheCreationTokens: event.cacheCreationTokens ?? 0,
-          cacheReadTokens: event.cacheReadTokens ?? 0,
-        });
+      const role = baseAgentName(event.agentName);
+      const key = `${role}:${event.model}`;
+      if (keysFromSubagent.has(key)) {
+        continue;
       }
+      addToGroup(role, event.model!, event);
     }
 
     // Upsert each group into MissionTokenUsage atomically

--- a/packages/kanban-viewer/src/lib/agent-name.ts
+++ b/packages/kanban-viewer/src/lib/agent-name.ts
@@ -1,0 +1,24 @@
+/**
+ * Agent name normalization for token-usage aggregation.
+ *
+ * Pipeline runs spawn pool instances of a single logical role — e.g. the
+ * Murdock role may run as `murdock`, `murdock-1`, `murdock-2`, `murdock-3`
+ * concurrently. Aggregating token usage by the raw instance name fragments
+ * one role's cost across N rows, making the per-agent breakdown unreadable.
+ *
+ * `baseAgentName` collapses a pool-instance name to its base role by stripping
+ * a trailing numeric instance suffix (`-<digits>`). It ONLY strips a numeric
+ * suffix, so legitimately-distinct agent names are never mangled. No A(i)-Team
+ * agent has a real name ending in `-<digits>` (hannibal, face, sosa, murdock,
+ * ba, lynch, amy, stockwell, tawnia, retro), so this is unambiguous.
+ *
+ * Examples:
+ *   baseAgentName('murdock-2')  → 'murdock'
+ *   baseAgentName('murdock')    → 'murdock'
+ *   baseAgentName('ba-13')      → 'ba'
+ *   baseAgentName('hannibal')   → 'hannibal'  (no suffix)
+ *   baseAgentName('claude-4-6') → 'claude-4'  (only the LAST -<digits> is stripped)
+ */
+export function baseAgentName(agentName: string): string {
+  return agentName.replace(/-\d+$/, '');
+}

--- a/packages/kanban-viewer/src/lib/token-cost.ts
+++ b/packages/kanban-viewer/src/lib/token-cost.ts
@@ -38,6 +38,16 @@ export interface TokenCostResult {
 /** Built-in pricing config (USD per 1M tokens). */
 const DEFAULT_PRICING: PricingConfig = {
   models: {
+    'claude-opus-4-8': {
+      input_per_1m: 5.00,
+      output_per_1m: 25.00,
+      cache_read_per_1m: 0.50,
+    },
+    'claude-opus-4-7': {
+      input_per_1m: 5.00,
+      output_per_1m: 25.00,
+      cache_read_per_1m: 0.50,
+    },
     'claude-opus-4-6': {
       input_per_1m: 15.00,
       output_per_1m: 75.00,

--- a/playbooks/orchestration-native.md
+++ b/playbooks/orchestration-native.md
@@ -1,6 +1,8 @@
 # Orchestration Playbook: Native Teams Mode (Multi-Instance)
 
-> **You are in NATIVE TEAMS mode.** Use `TeamCreate`, `Task` with `team_name`/`name` params, and `SendMessage` for coordination.
+> **You are in NATIVE TEAMS mode.** Spawn teammates with `Agent` (passing `name`), and coordinate with `SendMessage`.
+>
+> **API CHANGE (Claude Code ≥ 2.1.178):** `TeamCreate` and `TeamDelete` **no longer exist**. The team is **implicit** — every session with `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` has exactly one team, created automatically; cleanup is automatic on session exit. **Do NOT call `TeamCreate`/`TeamDelete`, and do NOT treat their absence as a reason to fall back to legacy mode.** Native teams is available whenever `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`; spawn teammates directly with `Agent`.
 
 This playbook EXTENDS the base native teams orchestration with **stage concurrency**: up to N items can be processed within the same stage simultaneously, each by its own agent instance. N is determined by `ateam scaling compute` (dep graph width × memory budget). When N=1, behaviour is identical to the base playbook (single instance per agent type, no suffixes).
 
@@ -10,28 +12,21 @@ Read `docs/ORCHESTRATION.md` for environment setup, permissions, and dispatch re
 
 | Tool | Purpose | Key Parameters |
 |------|---------|----------------|
-| `TeamCreate` | Create a team for the mission | `team_name`, `description` |
-| `Task` | Spawn a teammate agent | `team_name`, `name`, `subagent_type`, `prompt` |
-| `SendMessage` | Send messages to teammates | `type`, `recipient`, `content`, `summary` |
-| `SendMessage` (broadcast) | Message all teammates | `type: "broadcast"`, `content`, `summary` |
-| `SendMessage` (shutdown) | Request teammate shutdown | `type: "shutdown_request"`, `recipient` |
-| `TeamDelete` | Clean up team resources | (no params) |
+| `Agent` | Spawn a teammate agent | `name`, `subagent_type`, `description`, `prompt`, `run_in_background` |
+| `SendMessage` | Send a message to a teammate | `to`, `message`, `summary` |
 
-### SendMessage Types
+> **Team lifecycle is implicit** — there is no `TeamCreate` or `TeamDelete` (removed in 2.1.178). Spawning the first `Agent` participates in the session's implicit team automatically; cleanup happens on session exit.
+
+### SendMessage
+
+`SendMessage({ to, message, summary })` is the single coordination call — see the `teams-messaging` skill for the full message protocol (START / ACK / FYI / ALERT / DONE / shutdown). Canonical shape:
 
 ```text
 # Direct message to a specific teammate
-SendMessage(type: "message", recipient: "murdock-1", content: "...", summary: "Brief 5-10 word summary")
-
-# Broadcast to all teammates (use sparingly - expensive)
-SendMessage(type: "broadcast", content: "...", summary: "Brief summary")
-
-# Request teammate shutdown
-SendMessage(type: "shutdown_request", recipient: "murdock-1", content: "Work complete")
-
-# Approve/reject plan from teammate
-SendMessage(type: "plan_approval_response", request_id: "...", recipient: "ba-1", approve: true)
+SendMessage(to: "murdock-1", message: "...", summary: "Brief 5-10 word summary")
 ```
+
+Shutdown is requested with a `shutdown_request` message body to a teammate (see `teams-messaging`); there is no separate broadcast or team-teardown tool.
 
 ## Precheck Flow
 
@@ -179,11 +174,7 @@ ateam pool init
 
 ## Team Initialization
 
-At mission start, create a team:
-
-```text
-TeamCreate(team_name: "mission-{missionId}", description: "A(i)-Team mission: {mission name}")
-```
+**No explicit team creation.** The team is implicit (see the API-change note at the top) — there is nothing to call before spawning. Proceed directly to instance-pool initialization and lazy pre-warming. The first `Agent` spawn joins the session's implicit team automatically.
 
 ## Agent Pre-Warming (Lazy)
 
@@ -221,17 +212,17 @@ function spawn_lane(lane_number):
     Bash("ateam activity createActivityEntry --agent hannibal --message 'Spawning lane {lane_number} (lazy pre-warm triggered by capacity demand)' --level info")
 
     for instance in lane_instances:
-        Task(
-            team_name:    "mission-{missionId}",
+        Agent(
             name:         instance.name,
             subagent_type: agentTypeToSubagent(instance.agentType),
+            run_in_background: true,
             description:  "{instance.name}: standby",
             prompt:       "You are {instance.name} ({instance.agentType} instance {lane_number}).
                            Environment: export ATEAM_MISSION_ID='{missionId}'
                            Your FIRST action on startup:
                              1. Run: export ATEAM_MISSION_ID='{missionId}'
                              2. Send Hannibal a ready signal:
-                                SendMessage(to: 'hannibal', content: 'READY: {instance.name}')
+                                SendMessage(to: 'hannibal', message: 'READY: {instance.name}', summary: 'READY {instance.name}')
                            Then await work item assignments via SendMessage.
                            When receiving work, use exactly '--agent \"{instance.name}\"' in all
                            ateam agents-start and ateam agents-stop commands.
@@ -318,8 +309,8 @@ if ready != lane_agents:
     for agent in missing:
         Bash("ateam activity createActivityEntry --agent hannibal --message 'TIMEOUT: {agent} did not send READY within 60s — respawning' --level warning")
         # Kill the silent agent and respawn
-        SendMessage(type: "shutdown_request", recipient: agent, content: "No READY received — shutting down for respawn")
-        Task(... same params as original spawn for this agent ...)
+        SendMessage(to: agent, message: {type: "shutdown_request", reason: "No READY received — shutting down for respawn"}, summary: "shutdown {agent}")
+        Agent(... same params as original spawn for this agent ...)
 
     # Wait another 60s for respawned agents only
     respawn_deadline = now() + 60s
@@ -349,7 +340,7 @@ return len(ready)
 ```text
 # Mission start — spawn lane 1 only
 spawn_lane(1)
-# → Task spawn for murdock-1, ba-1, lynch-1, amy-1
+# → Agent spawn for murdock-1, ba-1, lynch-1, amy-1
 # → receive READY from all 4
 # → ateam pool mark-idle murdock-1 (then ba-1, lynch-1, amy-1)
 # → next_lane_to_spawn = 2
@@ -572,7 +563,7 @@ LOOP CONTINUOUSLY:
 
 ## Dispatch Helper
 
-The `dispatch(instance, item_id)` function decides whether to send a `SendMessage` (if instance already alive) or spawn a fresh `Task` (if never spawned or after shutdown):
+The `dispatch(instance, item_id)` function decides whether to send a `SendMessage` (if instance already alive) or spawn a fresh `Agent` (if never spawned or after shutdown):
 
 ```text
 function dispatch(instance, item_id):
@@ -580,16 +571,15 @@ function dispatch(instance, item_id):
 
     if instance was already spawned and is alive:
         SendMessage(
-            type:      "message",
-            recipient: instance.name,
-            content:   "New work: {item_id} - {title}\n{relevant file paths}\nFetch full details with `ateam items renderItem --id {item_id}`.\nUse '--agent \"{instance.name}\"' in agentStart/agentStop.",
+            to:        instance.name,
+            message:   "New work: {item_id} - {title}\n{relevant file paths}\nFetch full details with `ateam items renderItem --id {item_id}`.\nUse '--agent \"{instance.name}\"' in agentStart/agentStop.",
             summary:   "New {instance.agentType} work for {item_id}"
         )
     else:
-        Task(
-            team_name:    "mission-{missionId}",
+        Agent(
             name:         instance.name,
             subagent_type: agentTypeToSubagent(instance.agentType),
+            run_in_background: true,
             description:  "{instance.name}: {item title}",
             prompt:       "[agent prompt + work item context]
                            Use '--agent \"{instance.name}\"' in agentStart/agentStop.
@@ -599,7 +589,7 @@ function dispatch(instance, item_id):
 
 ## Dispatch Timeout Enforcement
 
-After dispatching work to any agent (via `SendMessage` or `Task`), Hannibal must enforce a **60-second acknowledgment timeout**. The expected signals are:
+After dispatching work to any agent (via `SendMessage` or `Agent`), Hannibal must enforce a **60-second acknowledgment timeout**. The expected signals are:
 
 - **ACK or FYI message** from the dispatched agent, OR
 - **`teammate_idle` event** (agent went idle, meaning it picked up the work)
@@ -627,8 +617,8 @@ function dispatch_with_timeout(instance, item_id):
     Bash("ateam pool release {instance.name}")
 
     # Respawn and redispatch
-    SendMessage(type: "shutdown_request", recipient: instance.name, content: "No ACK — shutting down for respawn")
-    Task(... same params as original spawn for this instance ...)
+    SendMessage(to: instance.name, message: {type: "shutdown_request", reason: "No ACK — shutting down for respawn"}, summary: "shutdown {instance.name}")
+    Agent(... same params as original spawn for this instance ...)
 
     # Wait 60s for the respawned agent's READY
     msg = receive next SendMessage (timeout: 60s)
@@ -658,8 +648,7 @@ active_instances[001] = "murdock-2"
 
 **First spawn (or re-spawn):**
 ```text
-Task(
-  team_name: "mission-{missionId}",
+Agent(
   name: "murdock-2",                          ← instance name, NOT "murdock"
   subagent_type: "ai-team:murdock",
   description: "murdock-2: {feature title}",
@@ -683,9 +672,8 @@ Task(
 **Subsequent work (instance already alive):**
 ```text
 SendMessage(
-  type: "message",
-  recipient: "murdock-2",
-  content: "New work: WI-005 - {title}\nTest file: {outputs.test}\nTypes file: {outputs.types}\nFetch full details with `ateam items renderItem --id WI-005`.\nFirst run: `ateam agents-start agentStart --itemId WI-005 --agent \"murdock-2\"`",
+  to: "murdock-2",
+  message: "New work: WI-005 - {title}\nTest file: {outputs.test}\nTypes file: {outputs.types}\nFetch full details with `ateam items renderItem --id WI-005`.\nFirst run: `ateam agents-start agentStart --itemId WI-005 --agent \"murdock-2\"`",
   summary: "New test work for WI-005"
 )
 ```
@@ -702,8 +690,7 @@ active_instances[001] = "ba-1"
 
 **First spawn:**
 ```text
-Task(
-  team_name: "mission-{missionId}",
+Agent(
   name: "ba-1",
   subagent_type: "ai-team:ba",
   description: "ba-1: {feature title}",
@@ -738,8 +725,7 @@ active_instances[001] = "lynch-1"
 
 **First spawn:**
 ```text
-Task(
-  team_name: "mission-{missionId}",
+Agent(
   name: "lynch-1",
   subagent_type: "ai-team:lynch",
   description: "lynch-1: {feature title}",
@@ -772,8 +758,7 @@ active_instances[001] = "amy-2"
 
 **First spawn:**
 ```text
-Task(
-  team_name: "mission-{missionId}",
+Agent(
   name: "amy-2",
   subagent_type: "ai-team:amy",
   description: "amy-2: {feature title}",
@@ -801,8 +786,7 @@ Task(
 After post-checks pass (Tawnia is never pre-warmed):
 
 ```text
-Task(
-  team_name: "mission-{missionId}",
+Agent(
   name: "tawnia",
   subagent_type: "ai-team:tawnia",
   description: "Tawnia: Documentation and final commit",
@@ -823,8 +807,7 @@ Task(
 **MANDATORY** — runs after Tawnia's DONE message confirms the final commit. Retro pulls token-usage, tool-histogram, skill-usage, and work-log data from the API to produce the structured retrospective report. **Without this step, MissionTokenUsage is never aggregated** (the retro subagent's POST is what triggers materialization) and no `retroReport` is written.
 
 ```text
-Task(
-  team_name: "mission-{missionId}",
+Agent(
   name: "retro",
   subagent_type: "ai-team:retro",
   description: "Retro: Mission retrospective",
@@ -903,7 +886,7 @@ The heartbeat is **mandatory** in native mode, not optional. It is the only thin
 
 ### First wakeup at mission start
 
-Schedule the first heartbeat immediately after `TeamCreate` and pre-warming lane 1, **before** entering the orchestration loop:
+Schedule the first heartbeat immediately after pre-warming lane 1, **before** entering the orchestration loop:
 
 ```text
 ScheduleWakeup(
@@ -1046,8 +1029,7 @@ When ALL items reach `done` stage, fetch `prdPath` from `ateam missions-current 
 **Always spawn a new Stockwell agent** (not pre-warmed, runs once):
 
 ```text
-Task(
-  team_name: "mission-{missionId}",
+Agent(
   name: "stockwell",
   subagent_type: "ai-team:stockwell",
   description: "Stockwell: Final Mission Review",
@@ -1148,7 +1130,7 @@ When the mission is complete (Tawnia DONE received), run these in order — **re
 2. **Shutdown all pre-warmed instances:**
 ```text
 for instance in instance_pool:
-    SendMessage(type: "shutdown_request", recipient: instance.name, content: "Mission complete")
+    SendMessage(to: instance.name, message: {type: "shutdown_request", reason: "Mission complete"}, summary: "shutdown {instance.name}")
 ```
 
 3. **Wait for shutdown approvals** (teammates auto-approve unless busy)
@@ -1158,10 +1140,7 @@ for instance in instance_pool:
 ateam pool destroy
 ```
 
-5. **Delete the team:**
-```text
-TeamDelete()
-```
+5. **Team teardown is automatic.** There is no `TeamDelete` (removed in 2.1.178) — the implicit team is cleaned up when the session exits. Nothing to call.
 
 Only send shutdown requests to instances that were actually spawned. Skip any that were never needed.
 
@@ -1176,10 +1155,7 @@ Native teams are ephemeral — they don't survive session restarts. On resume:
 
 2. **Re-determine N** (same concurrency detection logic as mission start)
 
-3. **Create fresh team:**
-   ```
-   TeamCreate(team_name: "mission-{missionId}", description: "Resumed A(i)-Team mission")
-   ```
+3. **No team to re-create.** The resumed session has its own implicit team — there is no `TeamCreate` step. Proceed directly to re-initializing the pool and respawning teammates with `Agent`.
 
 4. **Re-initialize instance pool** (same structure as before)
 
@@ -1195,7 +1171,7 @@ Native teams are ephemeral — they don't survive session restarts. On resume:
 
 6. **Read board state and re-spawn at current stages, marking idle only on confirmed READY:**
 
-   Mirror normal startup: re-spawn the lane (`Task` calls), wait for READY (use the same `wait_for_lane_ready(lane_number)` helper from "Lazy Lane Pre-Warming" above), and only then issue `ateam pool mark-idle <instance>` for each agent that actually sent READY. If a respawned agent fails to send READY within the 60s timeout, mark the lane failed (do NOT create its `.idle` file) and surface ALERT.
+   Mirror normal startup: re-spawn the lane (`Agent` calls), wait for READY (use the same `wait_for_lane_ready(lane_number)` helper from "Lazy Lane Pre-Warming" above), and only then issue `ateam pool mark-idle <instance>` for each agent that actually sent READY. If a respawned agent fails to send READY within the 60s timeout, mark the lane failed (do NOT create its `.idle` file) and surface ALERT.
    ```
    board = Bash("ateam board getBoard --json")
    active_instances = {}
@@ -1203,28 +1179,28 @@ Native teams are ephemeral — they don't survive session restarts. On resume:
    for item in testing stage:
        Bash("ateam board-release releaseItem --itemId {item_id}")
        claimed = claimInstance("murdock")
-       Task(team_name: "mission-{missionId}", name: claimed,
+       Agent(name: claimed,
             subagent_type: "ai-team:murdock", ...)
        active_instances[item_id] = claimed
 
    for item in implementing stage:
        Bash("ateam board-release releaseItem --itemId {item_id}")
        claimed = claimInstance("ba")
-       Task(team_name: "mission-{missionId}", name: claimed,
+       Agent(name: claimed,
             subagent_type: "ai-team:ba", ...)
        active_instances[item_id] = claimed
 
    for item in review stage:
        Bash("ateam board-release releaseItem --itemId {item_id}")
        claimed = claimInstance("lynch")
-       Task(team_name: "mission-{missionId}", name: claimed,
+       Agent(name: claimed,
             subagent_type: "ai-team:lynch", ...)
        active_instances[item_id] = claimed
 
    for item in probing stage:
        Bash("ateam board-release releaseItem --itemId {item_id}")
        claimed = claimInstance("amy")
-       Task(team_name: "mission-{missionId}", name: claimed,
+       Agent(name: claimed,
             subagent_type: "ai-team:amy", ...)
        active_instances[item_id] = claimed
    ```

--- a/prd/drafts/accurate-token-attribution.md
+++ b/prd/drafts/accurate-token-attribution.md
@@ -1,0 +1,215 @@
+---
+missionId: ~
+---
+
+# Accurate Per-Message Token Attribution
+
+**Author:** Josh / Claude  **Date:** 2026-06-06  **Status:** Draft
+
+## 1. Context & Background
+
+The token-usage tracking system (see `prd/completed/token-usage-tracking.md`) captures per-agent, per-model token cost for every mission. It works by having the `Stop` and `SubagentStop` hooks read an agent's transcript, **sum the `usage` block across all messages**, stamp the result with **the last model seen**, and POST it as one cumulative number. A downstream aggregation route groups those numbers by `(agentName, model)` and writes `MissionTokenUsage` rows that the dashboard reads.
+
+That design rested on an assumption stated explicitly in the original PRD (§7, "Edge Cases"):
+
+> "Multiple models in one transcript … The parser captures the last model encountered. This is a simplification — for the expected A(i)-Team usage patterns, each agent uses exactly one model throughout its session."
+
+**That assumption no longer holds.** The orchestrator session (Hannibal) now drifts between models within a single mission: the harness launches Claude Code with no `--model` flag, so the session defaults to Opus, while `/ai-team:run` and `/ai-team:tick` frontmatter pull it toward Sonnet — the session alternates across the multi-hour tick loop. Real telemetry for mission `M-test-harness-20260531-002` shows Hannibal firing 152 cumulative `stop` events split across `claude-opus-4-8` and `claude-sonnet-4-6`.
+
+When an agent spans two models, the current pipeline produces **wrong numbers in two independent ways**:
+
+1. **Cross-model double-count (over-reports).** Each `stop` event carries the *whole-session cumulative* total. When the session has touched two models, the aggregator keeps the latest `stop` *per model* and then **sums those rows** — but each row is essentially the same full cumulative total sampled twice. For `M-test-harness-20260531-002`, Hannibal's two rows (`$37.18` + `$0.73` at stored rates, or two ~full snapshots of ~52–53M cache-read tokens) represent one session counted ~twice. Verified from raw `HookEvent` data: the cumulative `cacheReadTokens` counter climbs monotonically across *both* models interleaved (3.1M → 3.3M → 5.4M …  → 52.3M opus, 53.1M sonnet) — it is one shared session counter, not two accumulations.
+
+2. **Model mis-attribution (mixes rates).** Even within one cumulative number, tokens generated under Opus and under Sonnet are summed together and stamped with whichever model appeared last. The per-model breakdown is therefore fiction whenever a session drifts.
+
+A third, related defect compounded operator confusion: until recently `ateam.config.json` had no pricing entry for `claude-opus-4-8` / `claude-opus-4-7`, so every Opus agent silently billed at the Sonnet fallback rate — under-reporting Opus cost by ~1.67×. That config gap is already fixed; this PRD does not re-litigate it but treats correct pricing as a precondition for trustworthy output.
+
+### Why this matters now
+
+Cost analysis has become a primary use of this data — model selection, effort tuning, and the Murdock extended-thinking runaway were all diagnosed from it. But every Hannibal figure required manual recomputation from raw events to be trusted, and intermediate analyses repeatedly shifted as each defect surfaced. The data model, not the analyst, is the problem: **we discard clean per-message deltas and reconstruct a lossy cumulative snapshot, then spend aggregation logic trying to undo the reconstruction.**
+
+### Ground truth is already in the transcript
+
+Every assistant message in a Claude Code transcript carries **its own `usage` block and its own `model`**. That is exactly one correctly-attributed cost record per API call. The fix is to stop destroying that structure.
+
+## 2. Problem Statement
+
+The token pipeline converts clean per-message, per-model usage deltas into a single cumulative per-session sum stamped with one model. This is lossy and forces fragile reconstruction downstream. When any agent uses more than one model in a session (now routine for Hannibal), the result is both **double-counted** (cross-model summing of cumulative snapshots) and **mis-attributed** (mixed-model tokens priced as one model). The numbers cannot be read off the dashboard and trusted; they require manual reconciliation against raw events.
+
+## 3. Goals & Success Metrics
+
+| Goal | Metric | Target |
+|---|---|---:|
+| Eliminate cross-model double-count | Mission total from dashboard vs. hand-computed from raw transcript deltas | Match within 1% |
+| Correct per-model attribution | For a model-drifting session, each model's tokens priced at its own rate | 100% correct (no mixed-model rows) |
+| Per-agent-type rollup | Pool instances (`murdock`, `murdock-1…`) summed under base role | One consolidated figure per role |
+| Stop re-analysis churn | Number of manual raw-event recomputations needed to trust a mission total | 0 |
+| No regression on single-model agents | Existing single-model agent totals (ba, amy, lynch) before vs. after | Unchanged within 1% |
+| Backfill historical missions | Recent archived missions re-aggregated to correct figures | All missions with token data |
+
+## 4. Scope
+
+### In Scope
+
+- Capture token usage **per assistant message, keyed by that message's own model**, rather than one summed-and-relabeled cumulative number per session.
+- Persist per-(agent, model) usage without relying on "latest cumulative snapshot" reconstruction.
+- Simplify the aggregation route to a straight group-by-and-sum over correctly-attributed records.
+- Preserve and incorporate the already-landed fixes: opus-4-7/4-8 pricing, correlationId-based stop dedup, and agent-variant (`-N`) consolidation.
+- A re-aggregation / backfill path so existing archived missions show corrected numbers.
+- Tests proving: model-drift attribution, no double-count, single-model parity, variant rollup, retry idempotency.
+
+### Out of Scope
+
+- Long-context (1M) premium pricing tiers — confirmed not applicable to the Sonnet 4.6 / Opus 4.8 generation (no above-200K surcharge), so flat per-token rates remain correct. No change needed.
+- Effort/thinking *control* (separate effort-cap work in `agents/*.md`); this PRD only ensures the resulting tokens are *measured* correctly.
+- Batch-discount or cache-TTL nuance modeling — list-price estimates remain the contract.
+- Any change to which hooks fire or the broader observability schema beyond token attribution.
+
+## 5. Root-Cause Summary (current vs. target)
+
+**Current (lossy):**
+```
+every Stop / SubagentStop:
+  read WHOLE transcript
+  inputTokens  = Σ all messages' input_tokens          ← cumulative
+  outputTokens = Σ all messages' output_tokens          ← cumulative
+  model        = last message's model                   ← attribution lost
+  → POST one number
+aggregation:
+  keep latest stop per (agent, model)                   ← reconstruction
+  SUM across models                                     ← double-counts drifting sessions
+```
+
+**Target (faithful):**
+```
+capture:
+  per assistant message → { model, input, output, cacheCreation, cacheRead, messageId }
+  attribute each message's tokens to ITS OWN model
+  PERSIST one row per message (durable per-message source of truth)
+aggregation:
+  GROUP BY (baseAgent, model) → SUM per-message deltas
+  (no "latest snapshot", no cross-model summing)
+```
+
+The target makes the four previously-identified robustness gaps largely moot: model mis-attribution (per-message model), cross-model double-count (no snapshot summing), cumulative-vs-delta confusion (store deltas as they are), and retry dedup (key on message id).
+
+## 6. Functional Requirements
+
+1. **Per-message extraction.** The transcript parser shall return, for a transcript, one usage record **per assistant message** — `{ messageId, model, inputTokens, outputTokens, cacheCreationTokens, cacheReadTokens }` — attributing each message's tokens to that message's own `model`. It shall no longer collapse to a single cumulative tuple with a single `model` field.
+2. **Per-message persistence (durable source of truth).** Each per-message usage record shall be persisted as its own row, keyed by `messageId` for idempotency. The store, not the transcript, becomes the durable per-message record — turn-level cost analysis must be answerable from the DB alone, without reading transcripts. Re-emitting the same message (retry, or a later stop re-reading the same transcript) shall upsert on `messageId`, never insert a duplicate.
+3. **Delta semantics, never cumulative snapshots.** Because storage is per-message deltas keyed by message id, the aggregator shall never sum two snapshots of the same session. Mission/agent totals are a `SUM` over distinct per-message rows.
+4. **Correct per-model pricing.** Each (agent, model) pair shall be priced at that model's configured rate; cache-creation at input rate, cache-read at the discounted rate (unchanged pricing math, correct inputs).
+5. **Agent-variant consolidation.** `murdock`, `murdock-1`, `murdock-2`, … shall roll up to base role `murdock` in the reported breakdown, summing genuinely-independent instance totals without double-counting (preserving the already-landed `baseAgentName` logic).
+6. **Re-aggregation.** A re-aggregation entry point shall recompute `MissionTokenUsage` for a given mission from the stored per-message rows, so a re-run or post-check-extended mission reflects current data. Per OQ1 (resolved: forward-only) this is NOT swept across archived missions; old missions captured under the legacy cumulative scheme are left as-is, with an optional one-off script for the recent `M-test-harness-20260531-*` set.
+7. **Per-turn queryability.** It shall be possible to answer "which messages/turns in this agent-session consumed the most tokens" from stored data (the capability that diagnosed the Murdock thinking spike), without reading transcripts.
+8. **Dashboard — dual views (per OQ3).** The token-usage surface shall present both: (a) a **per-agent rollup** (summed across that agent's models) as the default decision view, and (b) a **per-model view** — per-agent-per-model and a mission-wide per-model total. Both derive from the `MissionTokenUsage` `(agentName, model)` rows; the per-agent rollup is a sum across an agent's model rows. An agent spanning >1 model shall be visually flagged as a model-drift indicator.
+
+## 7. Non-Functional Requirements
+
+- **No new agent latency / no blocking.** Capture stays synchronous in the hook and within the existing fire-and-forget contract; parsing a multi-hundred-line transcript stays well under ~100ms.
+- **Backward compatible storage.** Prefer additive schema changes; never recreate live tables (per `docs/PLUGIN-DEV.md` migration rules and the "never replace the live DB" constraint).
+- **Test-first.** All behavior covered by the existing vitest suites (`scripts/hooks/__tests__`, `packages/kanban-viewer/src/__tests__/token-aggregation.test.ts`) extended; no net reduction in coverage.
+
+## 8. Data Model
+
+Per the resolved storage decision (OQ2: per-message rows retained), the design adds a **new per-message usage table** as the durable source of truth, and keeps `MissionTokenUsage` as a derived rollup over it.
+
+### 8.1 New: per-message usage table (source of truth)
+
+The current `HookEvent` carries a single `(model, inputTokens, outputTokens, cacheCreationTokens, cacheReadTokens)` tuple per event — insufficient to represent a multi-model session and lossy by construction. Rather than overload `HookEvent`, introduce a dedicated table (illustrative shape; final naming/columns are the decomposition's call):
+
+```
+MessageTokenUsage (new):
+  id                  Auto
+  messageId           String   Assistant message id (e.g. "msg_01FK…") — UNIQUE, idempotency key
+  projectId           String   → Project
+  missionId           String?  → Mission (nullable; same orphan caveat as HookEvent)
+  agentName           String   Raw agent/instance name (e.g. "murdock-1")
+  model               String   THIS message's model
+  inputTokens         Int
+  outputTokens        Int
+  cacheCreationTokens Int
+  cacheReadTokens     Int
+  timestamp           DateTime Message timestamp (enables per-turn / time-bucket analysis)
+
+  @@unique([messageId])           // upsert target — retries & re-reads never duplicate
+  @@index([missionId])
+  @@index([missionId, agentName])
+```
+
+- **Idempotency** is structural: re-emitting a message upserts on `messageId`. This subsumes the stop-event correlationId dedup concern for token data specifically — every message is its own dedup key.
+- **Volume**: ~150–400 rows per agent-session. Acceptable for SQLite at dogfood scale; `@@index([missionId, agentName])` keeps rollup queries fast. If volume becomes a concern at larger scale, a retention/prune policy on archived missions can follow (out of scope here).
+- Token fields currently on `HookEvent` may remain for backward compatibility / legacy missions but are **no longer the basis** for new aggregation. (Decomposition decides whether to stop populating them or keep them as a redundant per-session denormalization.)
+
+### 8.2 Derived: MissionTokenUsage (unchanged shape)
+
+`MissionTokenUsage` keeps its existing shape and `@@unique([missionId, agentName, model])` — the change is purely in derivation: it is now `SUM` over `MessageTokenUsage` grouped by `(baseAgentName(agentName), model)`, instead of the latest-cumulative-stop reconstruction. No client-side dashboard change required.
+
+### 8.3 Capture path change
+
+`parseTranscriptUsage` (in `scripts/hooks/lib/parse-transcript.js`) changes from "sum-all + last-model" to returning the per-message records of §6 FR-1. The Stop/SubagentStop hooks POST those records; the `POST /api/hooks/events` route (or a sibling endpoint) upserts them into `MessageTokenUsage` keyed by `messageId`. Because a stop fires every turn and re-reads the full transcript, most messages will be re-sent many times — upsert-on-messageId makes that idempotent and is the mechanism that finally kills the cumulative double-count at the source.
+
+## 9. Edge Cases & Error States
+
+- **Single-model session (the common case):** must produce identical results to today (minus the pricing correction). Regression-tested.
+- **Model drift mid-session (Hannibal):** each model's tokens attributed and priced separately; mission total equals the true cumulative, not 2×.
+- **Pre-change historical missions:** left under the legacy cumulative scheme (forward-only, per OQ1). Their dashboard figures retain the known double-count/mis-attribution; not recomputed except by the optional one-off script for the recent test-harness set. The new per-message table only backs missions run after the change.
+- **Transcript missing/unreadable:** unchanged behavior — skip token emission rather than fail the hook; the message rows simply aren't written.
+- **Empty / no-assistant-message transcript:** no `MessageTokenUsage` rows written; agent contributes zero, no row inflation.
+- **Same message re-sent across many stops (normal case):** upsert on `messageId` — one row regardless of how many stops re-read it. This is the primary mechanism preventing cumulative double-count.
+- **Message with no `id` in transcript:** cannot be deduped by key; define fallback (skip, or synthesize a stable key from session+index) in the technical approach so it neither duplicates nor silently drops.
+- **Pool instances completing in parallel:** each message carries its own raw `agentName` (e.g. `murdock-1`); rollup sums under base role without collapsing distinct sessions.
+
+## 10. Dependencies
+
+### Internal
+- `scripts/hooks/lib/parse-transcript.js` — `parseTranscriptUsage` rewrite (per-message records, not sum + last-model).
+- `scripts/hooks/observe-stop.js`, `observe-subagent.js` — emit per-message records.
+- `packages/kanban-viewer/src/app/api/hooks/events/route.ts` (or sibling endpoint) — accept + upsert per-message records on `messageId`.
+- `packages/kanban-viewer/prisma/schema.prisma` + migration — new `MessageTokenUsage` table (additive; `ALTER`/`CREATE TABLE`, never recreate live tables).
+- `packages/kanban-viewer/src/app/api/missions/[missionId]/token-usage/route.ts` — aggregation reads/sums `MessageTokenUsage`; re-aggregation entry point.
+- `packages/kanban-viewer/src/lib/agent-name.ts` — base-role consolidation (already landed).
+
+### External
+- Already-landed, uncommitted working-tree changes this builds on: opus-4-7/4-8 pricing, correlationId stop dedup + failure logging, agent-variant consolidation. This PRD assumes those are committed first (or that the mission branches from the current working tree).
+
+## 11. Risks & Decisions
+
+- **Interaction with in-flight fixes.** Three related fixes already sit uncommitted in the working tree (opus pricing, correlationId dedup + failure logging, agent-variant consolidation). Risk of conflicting edits to the same files. *Mitigation:* commit those first; this work branches from that baseline. Note the per-message `messageId` upsert (§8.3) largely subsumes the stop correlationId dedup for token data — decomposition should reconcile the two so they don't fight.
+- **New-table volume.** ~150–400 rows/agent/mission. Fine at dogfood scale; a prune/retention policy for archived missions is a possible follow-up if it grows.
+- **Messages lacking a stable id.** Dedup keys on `messageId`; the rare id-less message needs a defined fallback (see §9) to avoid duplicate or dropped rows.
+
+### Resolved Decisions
+1. **Backfill: forward-only (DECIDED 2026-06-16).** No general in-place backfill of archived missions. Historical events were captured cumulatively with last-model-wins, so a true per-model split is unrecoverable for them; a full backfill would run fragile code over old data only to produce authoritative-looking-but-approximate splits — recreating the trust problem this PRD exists to kill. Instead: the re-aggregation entry point (FR-6) remains (needed to re-aggregate a live/re-run mission), but it is NOT swept across all archived missions. A small one-off corrective script may write the hand-verified figures for the recent `M-test-harness-20260531-*` missions if needed. The deliverable is "new runs are correct," not "rewrite history."
+
+2. **Storage grain: per-message rows retained (DECIDED 2026-06-16).** Persist each assistant message's usage + its own model individually, rather than only a per-(session, model) rollup. Rationale: the per-message grain is what made the Murdock extended-thinking spike diagnosable (25K thinking tokens per trivial ACK turn), and we do not want that capability to depend on Claude Code transcripts remaining on disk — transcripts are not a guaranteed-durable record (temp dirs, rotation, cleanup). The DB becomes the durable per-message source of truth; `MissionTokenUsage` is a derived rollup over it. Cost: a new high-volume table (~150–400 rows/agent/mission) and aggregation that groups over the larger set. This makes per-turn cost analysis a first-class, queryable capability instead of a manual transcript dig. See §8 for the resulting data-model shape.
+
+3. **Dashboard views: both per-agent and per-model, first-class (DECIDED 2026-06-16).** Surface a per-agent rollup (default decision view) AND a per-model view (per-agent-per-model + mission-wide per-model totals). Pure presentation over the `(agentName, model)` rows; no extra data-model cost. An agent appearing under >1 model is surfaced as a model-drift indicator. See FR-8.
+
+3. **Dashboard views: both per-agent and per-model, first-class (DECIDED 2026-06-16).** Surface two complementary views: (a) a **per-agent rollup** (sum across that agent's models) as the decision-useful default — "Murdock cost $245," "Hannibal cost $62"; and (b) a **per-model view** — both per-agent-per-model (Hannibal's opus portion vs sonnet portion when it drifts) and a mission-wide per-model total (how much opus vs sonnet vs haiku did this whole mission burn). Both are pure presentations over the `MissionTokenUsage` `(agentName, model)` rows that OQ2's per-message store already produces, so this is a UI/route concern, not a data-model one. Emergent benefit: an agent appearing under >1 model in the per-agent view is an at-a-glance **model-drift indicator** (a config-bug signal worth flagging visually), not just an accounting detail.
+
+## 12. Validation Plan
+
+The canonical regression fixture is mission `M-test-harness-20260531-002`, whose correct breakdown has been hand-computed from raw transcript deltas:
+
+| Agent | Model | Output | Cache-read | Cost (correct) |
+|---|---|---:|---:|---:|
+| murdock | opus-4-8 | 5,995,002 | 46,433,147 | $245.23 |
+| hannibal | opus-4-8 | 265,579 | 102,877,448 | $61.97 (single cumulative, **not** ×2) |
+| ba | sonnet-4-6 | 609,037 | 70,024,718 | $33.67 |
+| amy | sonnet-4-6 | 194,111 | 17,582,666 | $11.72 |
+| lynch | sonnet-4-6 | 107,649 | 8,647,998 | $6.59 |
+| face | opus-4-8 | 12,606 | 2,142,433 | $2.79 |
+| sosa | opus-4-8 | 5,030 | 896,421 | $2.10 |
+| **TOTAL** | | | | **~$364** |
+
+Success = the corrected aggregation reproduces this table from stored events (hannibal as a single cumulative figure, all opus priced at opus rates), and the dashboard shows it without manual recomputation.
+
+## 13. Success Criteria
+
+- Dashboard mission total matches hand-computed raw-delta total within 1% for `M-test-harness-20260531-002` and the next live run.
+- Hannibal appears as a single correctly-priced figure (no cross-model double-count).
+- Single-model agents unchanged within 1%.
+- Pool variants rolled into base role.
+- No manual raw-event recomputation needed to trust a mission's numbers.
+- Existing token + hooks test suites green; new tests cover model-drift, no-double-count, variant rollup, and single-model parity.

--- a/scripts/hooks/__tests__/observe-stop-correlation.test.ts
+++ b/scripts/hooks/__tests__/observe-stop-correlation.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for the Stop-event correlationId scheme (FIX 1) and the observer
+ * failure log (FIX 3).
+ *
+ * FIX 1: Stop events must carry a correlationId that is
+ *   - STABLE across network retries of the same stop firing (so a retry dedups
+ *     to a single row), and
+ *   - DISTINCT across different turns (so legitimate per-turn cumulative stops
+ *     are NOT collapsed into one row).
+ * The scheme is `${session_id}:${lastAssistantMessageId}`, where the last
+ * assistant message id is read from the transcript.
+ *
+ * FIX 3: send failures must be appended to a local JSONL failure log so that
+ * dropped token events are observable, without breaking the fire-and-forget
+ * contract.
+ */
+
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { writeFileSync, mkdirSync, unlinkSync, readFileSync, existsSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  buildObserverPayload,
+  readLastAssistantMessageId,
+  sendObserverEvent,
+  logObserverFailure,
+  observerFailureLogPath,
+} from '../lib/observer.js';
+
+const tempFiles: string[] = [];
+
+function writeTempTranscript(messages: unknown[]): string {
+  const dir = join(tmpdir(), 'ateam-stop-correlation-test');
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `t-${Date.now()}-${Math.random().toString(36).slice(2)}.jsonl`);
+  writeFileSync(path, messages.map((m) => JSON.stringify(m)).join('\n'), 'utf8');
+  tempFiles.push(path);
+  return path;
+}
+
+/** Build a stop correlationId exactly as observe-stop.js does. */
+function buildStopCorrelationId(sessionId: string, transcriptPath: string | undefined): string | undefined {
+  const lastId = readLastAssistantMessageId(transcriptPath);
+  if (!lastId) return undefined;
+  return sessionId ? `${sessionId}:${lastId}` : lastId;
+}
+
+afterEach(() => {
+  for (const f of tempFiles) {
+    try { unlinkSync(f); } catch {}
+  }
+  tempFiles.length = 0;
+  vi.restoreAllMocks();
+});
+
+describe('readLastAssistantMessageId', () => {
+  it('returns the id of the LAST assistant message', () => {
+    const path = writeTempTranscript([
+      { type: 'assistant', message: { id: 'msg_first', role: 'assistant', usage: {} } },
+      { type: 'user', message: { role: 'user', content: 'x' } },
+      { type: 'assistant', message: { id: 'msg_last', role: 'assistant', usage: {} } },
+    ]);
+    expect(readLastAssistantMessageId(path)).toBe('msg_last');
+  });
+
+  it('skips trailing non-assistant lines and blank lines', () => {
+    const path = writeTempTranscript([
+      { type: 'assistant', message: { id: 'msg_real', role: 'assistant' } },
+      { type: 'user', message: { role: 'user', content: 'done' } },
+    ]);
+    // Append a blank line to simulate trailing newline.
+    writeFileSync(path, readFileSync(path, 'utf8') + '\n', 'utf8');
+    expect(readLastAssistantMessageId(path)).toBe('msg_real');
+  });
+
+  it('returns null for an unreadable transcript', () => {
+    expect(readLastAssistantMessageId('/nonexistent/transcript.jsonl')).toBeNull();
+  });
+
+  it('returns null when no assistant message id is present', () => {
+    const path = writeTempTranscript([
+      { type: 'user', message: { role: 'user', content: 'hi' } },
+    ]);
+    expect(readLastAssistantMessageId(path)).toBeNull();
+  });
+});
+
+describe('Stop correlationId scheme — retry-stable but turn-distinct', () => {
+  it('produces the SAME correlationId across retries of the same turn (same transcript)', () => {
+    const path = writeTempTranscript([
+      { type: 'assistant', message: { id: 'msg_turn1', role: 'assistant', usage: { input_tokens: 1 } } },
+    ]);
+    const a = buildStopCorrelationId('sess-1', path);
+    const b = buildStopCorrelationId('sess-1', path);
+    expect(a).toBe('sess-1:msg_turn1');
+    expect(b).toBe(a); // retry → identical id → dedups to one row
+  });
+
+  it('produces DISTINCT correlationIds across different turns (different last message id)', () => {
+    const turn1 = writeTempTranscript([
+      { type: 'assistant', message: { id: 'msg_turn1', role: 'assistant', usage: { input_tokens: 1 } } },
+    ]);
+    const turn2 = writeTempTranscript([
+      { type: 'assistant', message: { id: 'msg_turn1', role: 'assistant', usage: { input_tokens: 1 } } },
+      { type: 'assistant', message: { id: 'msg_turn2', role: 'assistant', usage: { input_tokens: 2 } } },
+    ]);
+    const c1 = buildStopCorrelationId('sess-1', turn1);
+    const c2 = buildStopCorrelationId('sess-1', turn2);
+    expect(c1).toBe('sess-1:msg_turn1');
+    expect(c2).toBe('sess-1:msg_turn2');
+    expect(c1).not.toBe(c2); // distinct turns → distinct rows (not collapsed)
+  });
+
+  it('falls back to undefined correlationId when no assistant message id is available', () => {
+    const path = writeTempTranscript([
+      { type: 'user', message: { role: 'user', content: 'nothing here' } },
+    ]);
+    expect(buildStopCorrelationId('sess-1', path)).toBeUndefined();
+  });
+});
+
+describe('buildObserverPayload — correlationId override for stop events', () => {
+  it('uses the provided correlationId for stop events', () => {
+    const payload = buildObserverPayload(
+      { hook_event_name: 'Stop', session_id: 'sess-9' },
+      'hannibal',
+      { correlationId: 'sess-9:msg_abc' }
+    );
+    expect(payload).not.toBeNull();
+    expect(payload!.eventType).toBe('stop');
+    expect(payload!.correlationId).toBe('sess-9:msg_abc');
+  });
+
+  it('falls back to a random UUID when no correlationId override is given', () => {
+    const p1 = buildObserverPayload({ hook_event_name: 'PreToolUse', tool_name: 'Bash' }, 'murdock');
+    const p2 = buildObserverPayload({ hook_event_name: 'PreToolUse', tool_name: 'Bash' }, 'murdock');
+    expect(p1!.correlationId).toBeTruthy();
+    expect(p1!.correlationId).not.toBe(p2!.correlationId);
+  });
+});
+
+describe('FIX 3 — observer failure logging', () => {
+  let failureLog: string;
+
+  beforeEach(() => {
+    // Point the failure log at an isolated temp dir.
+    process.env.CLAUDE_PROJECT_DIR = join(tmpdir(), `ateam-fail-log-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(process.env.CLAUDE_PROJECT_DIR, { recursive: true });
+    failureLog = observerFailureLogPath();
+  });
+
+  afterEach(() => {
+    try { rmSync(process.env.CLAUDE_PROJECT_DIR!, { recursive: true, force: true }); } catch {}
+    delete process.env.CLAUDE_PROJECT_DIR;
+  });
+
+  it('logObserverFailure appends a structured JSON line', () => {
+    logObserverFailure({ url: 'http://x/api', status: 500, error: 'boom', agentName: 'hannibal', eventType: 'stop' });
+    expect(existsSync(failureLog)).toBe(true);
+    const lines = readFileSync(failureLog, 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+    const rec = JSON.parse(lines[0]);
+    expect(rec).toMatchObject({ url: 'http://x/api', status: 500, error: 'boom', agentName: 'hannibal', eventType: 'stop' });
+    expect(typeof rec.timestamp).toBe('string');
+  });
+
+  it('sendObserverEvent logs a failure line when the response is not ok', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: async () => 'service unavailable',
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const ok = await sendObserverEvent({
+      eventType: 'stop',
+      agentName: 'hannibal',
+      status: 'stopped',
+      summary: 'hannibal stopped',
+      timestamp: new Date().toISOString(),
+      correlationId: 'sess:msg_1',
+    });
+
+    expect(ok).toBe(false);
+    const rec = JSON.parse(readFileSync(failureLog, 'utf8').trim());
+    expect(rec.status).toBe(503);
+    expect(rec.agentName).toBe('hannibal');
+    expect(rec.eventType).toBe('stop');
+  });
+
+  it('sendObserverEvent logs a failure line when fetch throws (network error)', async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const ok = await sendObserverEvent({
+      eventType: 'stop',
+      agentName: 'hannibal',
+      status: 'stopped',
+      summary: 'hannibal stopped',
+      timestamp: new Date().toISOString(),
+    });
+
+    expect(ok).toBe(false);
+    const rec = JSON.parse(readFileSync(failureLog, 'utf8').trim());
+    expect(rec.status).toBeNull();
+    expect(rec.error).toContain('ECONNREFUSED');
+    expect(rec.eventType).toBe('stop');
+  });
+
+  it('does not write a failure line on success', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 201, text: async () => '' });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const ok = await sendObserverEvent({
+      eventType: 'stop',
+      agentName: 'hannibal',
+      status: 'stopped',
+      summary: 'ok',
+      timestamp: new Date().toISOString(),
+    });
+
+    expect(ok).toBe(true);
+    expect(existsSync(failureLog)).toBe(false);
+  });
+});

--- a/scripts/hooks/__tests__/parse-transcript.test.ts
+++ b/scripts/hooks/__tests__/parse-transcript.test.ts
@@ -85,6 +85,77 @@ describe('parseTranscriptUsage() - happy path', () => {
   });
 });
 
+describe('parseTranscriptUsage() - duplicate message emissions', () => {
+  it('should count each message.id exactly once when the same message is written multiple times', () => {
+    // Claude Code writes the same assistant message to the transcript several
+    // times as it streams then finalizes; each emission carries the SAME usage.
+    // Summing all emissions over-counts (~2.6-3.4x in real transcripts). The
+    // parser must dedup by message.id so each message contributes usage once.
+    const msgA = {
+      type: 'assistant',
+      message: {
+        id: 'msg_A',
+        model: 'claude-sonnet-4-6',
+        usage: {
+          input_tokens: 1000,
+          output_tokens: 200,
+          cache_creation_input_tokens: 5000,
+          cache_read_input_tokens: 100,
+        },
+      },
+    };
+    const msgB = {
+      type: 'assistant',
+      message: {
+        id: 'msg_B',
+        model: 'claude-sonnet-4-6',
+        usage: {
+          input_tokens: 50,
+          output_tokens: 300,
+          cache_creation_input_tokens: 2000,
+          cache_read_input_tokens: 6000,
+        },
+      },
+    };
+    // msgA emitted 3x, msgB emitted 2x — as Claude Code actually does.
+    const path = writeTempTranscript([msgA, msgA, msgA, msgB, msgB]);
+    tempFiles.push(path);
+
+    const result = parseTranscriptUsage(path);
+
+    // Each distinct message counted once: A + B
+    expect(result.inputTokens).toBe(1050);        // 1000 + 50, NOT 3*1000 + 2*50
+    expect(result.outputTokens).toBe(500);        // 200 + 300
+    expect(result.cacheCreationTokens).toBe(7000); // 5000 + 2000, NOT 15000 + 4000
+    expect(result.cacheReadTokens).toBe(6100);     // 100 + 6000
+    expect(result.model).toBe('claude-sonnet-4-6');
+  });
+
+  it('should sum usage from messages that lack an id (cannot dedup, assume distinct)', () => {
+    // Older/malformed transcripts may omit message.id. Those cannot be deduped,
+    // so each usage-bearing line counts once (summed) — preserving prior behavior.
+    const noId = {
+      type: 'assistant',
+      message: {
+        model: 'claude-sonnet-4-6',
+        usage: {
+          input_tokens: 100,
+          output_tokens: 10,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+      },
+    };
+    const path = writeTempTranscript([noId, noId]);
+    tempFiles.push(path);
+
+    const result = parseTranscriptUsage(path);
+    // No id => both lines count (summed): 100 + 100
+    expect(result.inputTokens).toBe(200);
+    expect(result.outputTokens).toBe(20);
+  });
+});
+
 describe('parseTranscriptUsage() - missing/unreadable file', () => {
   it('should return null values when file does not exist', () => {
     const result = parseTranscriptUsage('/nonexistent/path/transcript.jsonl');

--- a/scripts/hooks/lib/observer.js
+++ b/scripts/hooks/lib/observer.js
@@ -10,13 +10,94 @@
  * CLAUDE_PLUGIN_ROOT, CLAUDE_PROJECT_DIR.
  */
 
-import { readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'fs';
+import { readFileSync, writeFileSync, unlinkSync, mkdirSync, appendFileSync } from 'fs';
 import { randomUUID, createHash } from 'crypto';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { resolveAgent } from './resolve-agent.js';
 
 const AGENT_MAP_DIR = join(tmpdir(), 'ateam-agent-map');
+
+/**
+ * Path for the best-effort observer failure log (FIX 3). One JSON object per
+ * line. Lives under CLAUDE_PROJECT_DIR when available so failures are visible
+ * alongside the project, falling back to the OS tmp dir otherwise.
+ */
+function observerFailureLogPath() {
+  const base = process.env.CLAUDE_PROJECT_DIR || tmpdir();
+  return join(base, '.ateam-observer-failures.log');
+}
+
+/**
+ * Appends a one-line structured record describing an observer send failure.
+ *
+ * This makes silent network failures observable without breaking the
+ * fire-and-forget contract: it is fully synchronous, wrapped in try/catch,
+ * and never throws back into the caller. It deliberately does NOT await any
+ * network/IO that could stall the agent — a local append is the only side
+ * effect.
+ *
+ * @param {Object} record - { url, status, error, agentName, eventType }
+ */
+function logObserverFailure(record) {
+  try {
+    const line = JSON.stringify({
+      timestamp: new Date().toISOString(),
+      url: record.url ?? null,
+      status: record.status ?? null,
+      error: record.error ?? null,
+      agentName: record.agentName ?? null,
+      eventType: record.eventType ?? null,
+    });
+    appendFileSync(observerFailureLogPath(), line + '\n');
+  } catch {
+    // Never let failure logging break the hook.
+  }
+}
+
+/**
+ * Reads the `id` of the LAST assistant message in a Claude Code JSONL
+ * transcript. Used to build a per-turn-stable correlationId for Stop events.
+ *
+ * Why the last assistant message id:
+ *   - It is STABLE across network retries of the same Stop hook firing (the
+ *     transcript is identical on retry), so a retry dedups to one row.
+ *   - It is DISTINCT across different turns (each turn ends with a new
+ *     assistant message id), so legitimate per-turn cumulative Stop events are
+ *     NOT collapsed into one row.
+ *
+ * Returns null if the file is unreadable or no assistant message id is found,
+ * in which case the caller falls back to a non-deduping random id.
+ *
+ * @param {string} transcriptPath - Absolute path to the .jsonl transcript
+ * @returns {string|null}
+ */
+function readLastAssistantMessageId(transcriptPath) {
+  if (!transcriptPath) return null;
+  let content;
+  try {
+    content = readFileSync(transcriptPath, 'utf8');
+  } catch {
+    return null;
+  }
+
+  const lines = content.split('\n');
+  // Walk from the end to find the most recent assistant message id.
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    if (!line.trim()) continue;
+    try {
+      const entry = JSON.parse(line);
+      const id = entry?.message?.id;
+      if ((entry?.type === 'assistant' || entry?.message?.role === 'assistant') && typeof id === 'string' && id) {
+        return id;
+      }
+    } catch {
+      // Skip malformed lines.
+    }
+  }
+  return null;
+}
 
 function hashArgs(args) {
   const input = typeof args === 'string' ? args : JSON.stringify(args ?? '');
@@ -101,9 +182,13 @@ function readHookInput() {
  *
  * @param {Object} hookInput - Parsed stdin JSON from Claude Code
  * @param {string} agentNameArg - Agent name passed as CLI arg (process.argv[2])
+ * @param {Object} [options] - Optional overrides
+ * @param {string} [options.correlationId] - Explicit correlationId (used for
+ *   Stop events, where a per-turn-stable id enables retry dedup). When omitted,
+ *   a random UUID is generated (matching the previous behavior).
  * @returns {Object|null} Payload object or null if invalid
  */
-function buildObserverPayload(hookInput, agentNameArg) {
+function buildObserverPayload(hookInput, agentNameArg, options = {}) {
   try {
     const toolName = hookInput.tool_name || '';
     const sessionId = hookInput.session_id || '';
@@ -161,8 +246,13 @@ function buildObserverPayload(hookInput, agentNameArg) {
       summary = `${eventType}: ${agentName}`;
     }
 
-    // Generate a correlation ID (UUID v4)
-    const correlationId = randomUUID();
+    // Correlation ID.
+    // For Stop events the caller passes a per-turn-stable id (session_id +
+    // last assistant message id) so that network retries of the SAME stop
+    // firing dedup to one row, while legitimate per-turn cumulative stops stay
+    // distinct. For all other events we keep a fresh UUID (no dedup intended
+    // beyond the pre/post tool-use pairing the caller may supply).
+    const correlationId = options.correlationId || randomUUID();
 
     // Include session_id in payload for grouping events by agent session
     const payloadData = {};
@@ -232,13 +322,41 @@ async function sendObserverEvent(payload) {
     if (!response.ok) {
       const text = await response.text().catch(() => '');
       process.stderr.write(`[observer] POST ${url} → ${response.status}: ${text}\n`);
+      // FIX 3: record the failure to a local log so dropped token events are
+      // observable (stderr alone is invisible once the hook process exits).
+      logObserverFailure({
+        url,
+        status: response.status,
+        error: text || null,
+        agentName: payload?.agentName,
+        eventType: payload?.eventType,
+      });
     }
 
     return response.ok;
   } catch (err) {
     process.stderr.write(`[observer] POST ${url} failed: ${err.message}\n`);
+    // FIX 3: a thrown fetch (network error, DNS, CF Access redirect, etc.)
+    // drops the event silently — capture it in the local failure log.
+    logObserverFailure({
+      url,
+      status: null,
+      error: err.message,
+      agentName: payload?.agentName,
+      eventType: payload?.eventType,
+    });
     return false;
   }
 }
 
-export { readHookInput, buildObserverPayload, sendObserverEvent, registerAgent, unregisterAgent, lookupAgent };
+export {
+  readHookInput,
+  buildObserverPayload,
+  sendObserverEvent,
+  registerAgent,
+  unregisterAgent,
+  lookupAgent,
+  readLastAssistantMessageId,
+  logObserverFailure,
+  observerFailureLogPath,
+};

--- a/scripts/hooks/lib/parse-transcript.js
+++ b/scripts/hooks/lib/parse-transcript.js
@@ -29,10 +29,19 @@ export function parseTranscriptUsage(transcriptPath) {
     return { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, model: null };
   }
 
-  let inputTokens = 0;
-  let outputTokens = 0;
-  let cacheCreationTokens = 0;
-  let cacheReadTokens = 0;
+  // Claude Code writes the SAME assistant message to the transcript multiple
+  // times as it streams and then finalizes (typically 2-3 emissions per message,
+  // each carrying the message's usage). Naively summing every line over-counts
+  // token usage by ~2.6-3.4x (measured across real transcripts). We therefore
+  // dedup by `message.id`: each distinct message contributes its usage exactly
+  // once. The per-message usage is a DELTA (not a running cumulative), so summing
+  // the deduped per-message values is correct.
+  //
+  // Lines that carry usage but no message.id (older transcripts, malformed
+  // entries) cannot be deduped — they are summed under a synthetic per-line key
+  // so behavior is unchanged for them (no id => assume distinct).
+  const usageById = new Map();
+  let syntheticKey = 0;
   let model = null;
 
   for (const line of lines) {
@@ -40,17 +49,35 @@ export function parseTranscriptUsage(transcriptPath) {
       const entry = JSON.parse(line);
       const usage = entry?.message?.usage;
       if (usage) {
-        inputTokens += usage.input_tokens || 0;
-        outputTokens += usage.output_tokens || 0;
-        cacheCreationTokens += usage.cache_creation_input_tokens || 0;
-        cacheReadTokens += usage.cache_read_input_tokens || 0;
-      }
-      if (usage && entry?.message?.model) {
-        model = entry.message.model;
+        const id = entry?.message?.id;
+        // No id => cannot dedup; use a unique synthetic key so it still counts once.
+        const key = id != null ? `id:${id}` : `line:${syntheticKey++}`;
+        // last-write-wins for a repeated id: every emission of a message carries
+        // the same final usage, so overwriting is equivalent and idempotent.
+        usageById.set(key, {
+          input: usage.input_tokens || 0,
+          output: usage.output_tokens || 0,
+          cacheCreation: usage.cache_creation_input_tokens || 0,
+          cacheRead: usage.cache_read_input_tokens || 0,
+        });
+        if (entry?.message?.model) {
+          model = entry.message.model;
+        }
       }
     } catch {
       // Skip malformed lines
     }
+  }
+
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let cacheCreationTokens = 0;
+  let cacheReadTokens = 0;
+  for (const u of usageById.values()) {
+    inputTokens += u.input;
+    outputTokens += u.output;
+    cacheCreationTokens += u.cacheCreation;
+    cacheReadTokens += u.cacheRead;
   }
 
   // If no valid lines had usage data at all, still return zero counts

--- a/scripts/hooks/observe-stop.js
+++ b/scripts/hooks/observe-stop.js
@@ -9,13 +9,28 @@
  * Agent name is passed as CLI arg (process.argv[2]) from frontmatter hooks.
  */
 
-import { readHookInput, buildObserverPayload, sendObserverEvent } from './lib/observer.js';
+import { readHookInput, buildObserverPayload, sendObserverEvent, readLastAssistantMessageId } from './lib/observer.js';
 import { parseTranscriptUsage, parseAdvanceFlagUsage, parseAgentStopItemId } from './lib/parse-transcript.js';
 
 const hookInput = readHookInput();
 const agentName = process.argv[2] || undefined;
 
-const payload = buildObserverPayload(hookInput, agentName);
+// Build a per-turn-stable correlationId for Stop events so retries of the SAME
+// stop firing dedup to a single row, while distinct per-turn cumulative stops
+// remain separate rows. Composition: `${session_id}:${lastAssistantMessageId}`.
+//   - session_id scopes the id to this session (avoids cross-session collisions
+//     on the globally-but-not-guaranteed-unique message id).
+//   - lastAssistantMessageId is identical on retry (same transcript) but
+//     changes every turn (each turn ends with a new assistant message id).
+// Fallback when no assistant message id is available: omit the correlationId
+// (the route then always stores the event — no dedup, but no data loss either).
+const sessionId = hookInput.session_id || '';
+const lastAssistantMessageId = readLastAssistantMessageId(hookInput.transcript_path);
+const stopCorrelationId = lastAssistantMessageId
+  ? (sessionId ? `${sessionId}:${lastAssistantMessageId}` : lastAssistantMessageId)
+  : undefined;
+
+const payload = buildObserverPayload(hookInput, agentName, { correlationId: stopCorrelationId });
 if (payload) {
   // On Stop events, parse transcript for token usage and advance flag, then merge into payload
   const transcriptPath = hookInput.transcript_path;

--- a/skills/ateam-cli/SKILL.md
+++ b/skills/ateam-cli/SKILL.md
@@ -93,12 +93,43 @@ ateam board-release releaseItem --itemId WI-001
 # List all items
 ateam items listItems
 
-# Get a specific item
-ateam items getItem --id WI-001
+# Get a specific item (positional <id>)
+ateam items getItem WI-001
 
-# Render item as markdown (useful for reading briefings)
-ateam items renderItem --id WI-001
+# Render item as markdown (positional <id>)
+ateam items renderItem WI-001
+
+# Update item fields (positional <id>)
+ateam items updateItem WI-001 --title "New title" --objective "..."
+
+# WRONG — --id does not exist on these commands:
+# ateam items getItem --id WI-001    ← error: unknown flag --id
+# ateam items renderItem --id WI-001 ← error: unknown flag --id
+# ateam items updateItem --id WI-001 ← error: unknown flag --id
+
+# Create an item — output flags are DOTTED, not camelCase
+ateam items createItem \
+  --title "User can filter products by category" \
+  --type feature \
+  --description "Executive summary for the kanban board" \
+  --objective "One behavioral sentence describing the outcome" \
+  --acceptance "POST /api/x returns 201" \
+  --acceptance "Invalid input returns 400" \
+  --context "Integrates with ProductService (src/services/product.ts)" \
+  --outputs.test "src/__tests__/feature.test.ts" \
+  --outputs.impl "src/services/feature.ts" \
+  --outputs.types "src/types/feature.ts"
 ```
+
+> **createItem flag gotchas — these cause the most failed planning runs:**
+>
+> - **Output flags are dotted:** `--outputs.test`, `--outputs.impl`, `--outputs.types`. NOT `--outputTest`, `--output-test`, `--outputs-test`, or `--outputImpl`. Wrong forms fail with `Error: unknown flag`. `--outputs.types` is optional; provide `--outputs.test` and `--outputs.impl` for every code-bearing item.
+> - **`--acceptance` is repeatable** — pass it once per criterion.
+> - **`--type` is one of** `feature | bug | enhancement | task`.
+> - **Create items one at a time, sequentially — never batch.** Issue each `createItem` as its own `Bash` call, confirm success, then run the next. If you put several `createItem` calls in a single parallel tool block and the first errors, the harness cancels the rest of the batch, turning one typo into a mass failure and burning item IDs.
+> - **When a flag is rejected, run `ateam items createItem --help`** to see the real flag names instead of guessing.
+
+After creating, verify with `ateam items listItems` or `ateam board getBoard`.
 
 ### Missions
 


### PR DESCRIPTION
## Problem

Starting the A(i)-Team intermittently falls back to **legacy** orchestration instead of native teams, with logs like:

> TeamCreate isn't in the deferred tools list. Let me load the legacy orchestration playbook as a fallback.

## Root cause (confirmed, not inferred)

Diagnosed from a real harness session on **Claude Code 2.1.195** + the official changelog:

- `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` **is** set and native mode **is** detected (`AGENT_TEAMS=1`, native playbook loads). Config was never the problem.
- **`TeamCreate` and `TeamDelete` were removed in CC 2.1.178.** Teams are now **implicit** — one per session, auto-created on first `Agent` spawn, auto-cleaned on session exit.
- Our `orchestration-native.md` was written against the pre-2.1.178 API and calls `TeamCreate(...)` first. That tool no longer exists, so the agent hit a dead tool and **non-deterministically** either improvised the modern API or bailed to the legacy playbook — hence the flaky behavior.
- The same session shows the **working modern pattern**: spawn with `Agent({subagent_type, name, run_in_background, prompt})`, coordinate with `SendMessage({to, message, summary})` (193 successful calls).

## Changes

- **`playbooks/orchestration-native.md`**: remove `TeamCreate`/`TeamDelete` (team is implicit; added an explicit API-change note so the fallback isn't reintroduced); replace every `Task(team_name:, name:, ...)` spawn with `Agent(name:, subagent_type:, run_in_background:, ...)`; align the API table + `SendMessage` examples to the confirmed `{to, message, summary}` shape; defer message-protocol detail to the `teams-messaging` skill.
- **`commands/plan.md`**: Face/Sosa planning spawns `Task(` → `Agent(`.
- **`commands/run.md` / `commands/resume.md`**: fix the "native TeamCreate/SendMessage" mode description → "native Agent/SendMessage".

## Scope notes

- `SendMessage` itself was **not broken** (confirmed working in-session); only the playbook's stale example syntax was aligned. No message-protocol shapes were invented.
- Legacy playbook untouched.

## Testing

- All command + hook suites pass: **425 tests**.
- No residual `TeamCreate(`/`TeamDelete(`/`team_name:` calls remain in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added base-role name normalization to improve token rollups across pooled instances.
  * Added stop-event correlation for more reliable retry deduplication, plus observer failure logging.
  * Expanded Claude Opus pricing coverage for additional model variants.
* **Bug Fixes**
  * Improved stop-event retry handling so duplicates update to the latest stored data.
  * Corrected token aggregation and transcript accounting to reduce phantom bleed-through and double-counting.
* **Documentation**
  * Refreshed CLI and orchestration guidance, including dotted `--outputs.*` flags, one-by-one item creation, and dispatch-mode wording.
* **Tests**
  * Added/expanded coverage for correlation, token aggregation edge cases, and transcript deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->