### PR TITLE
chore: sync plugin manifest to 1.8.0 and require CLI 1.8.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
         "repo": "theaiteam-dev/the-ai-team-plugin"
       },
       "description": "Parallel Agent Orchestration - transforms PRDs into working, tested code through a TDD pipeline with specialized agents.",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "author": {
         "name": "Josh / Arcane Ops"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "ai-team",
   "description": "Parallel Agent Orchestration - The A(i)-Team transforms PRDs into working, tested code",
-  "version": "1.7.0",
-  "minCliVersion": "1.6.1",
+  "version": "1.8.0",
+  "minCliVersion": "1.8.0",
   "author": {
     "name": "Josh / Arcane Ops"
   }

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ data/*.db-shm
 
 # Observer hook failure log (runtime telemetry, not source)
 .ateam-observer-failures.log
+
+# Private prod deployment runbook — references personal infra (arcane-k8s,
+# cluster URLs, GHCR org). Kept local; this is a public/OSS repo.
+docs/PROD-DEPLOY.md


### PR DESCRIPTION
## Summary

The prod kanban-viewer is now on **v1.8.0** (ADR baking + Mission Learning Loop + fingerprint tuning, PR #42), but the plugin manifest was never bumped — semantic-release tags/builds but doesn't touch `plugin.json`/`marketplace.json`. This left the installed plugin unable to pull the new work cleanly and the bundled CLI pinned old.

## Changes

- `version` **1.7.0 → 1.8.0** in `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`
- `minCliVersion` **1.6.1 → 1.8.0** in `plugin.json` — the `bin/ateam` wrapper only auto-downloads a newer CLI when the cached binary is *below* this floor. At 1.6.1, a cached 1.6.1 binary satisfied it and never upgraded, so the new `ateam learnings …` / `ateam tuning …` subcommands would be missing even after updating the plugin files. `ateam.config.json` pins `ateamCliVersion: latest` (→ v1.8.0), so there's no download conflict.
- gitignore the private prod deploy runbook (`docs/PROD-DEPLOY.md`) so it never lands in this public repo

## Why not a `feat:`/`fix:`

`chore:` intentionally — the code already shipped as v1.8.0; this only syncs metadata and must **not** trigger another semantic-release (which would mint a spurious v1.9.0).

## Follow-up (not in this PR)

Wire semantic-release to bump these manifest fields automatically so they stop drifting each release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin and marketplace metadata to version 1.8.0.
  * Raised the minimum supported CLI version to 1.8.0.
  * Added a deployment document to ignored files so it won’t be committed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->