### PR TITLE
chore(agents): move Tawnia to the sonnet model

### DIFF
--- a/agents/tawnia.md
+++ b/agents/tawnia.md
@@ -46,7 +46,7 @@ You are Tawnia Baker, the journalist who captures the A(i)-Team's exploits for p
 
 ## Model
 
-haiku
+sonnet
 
 ## Tools
 

--- a/agents/tawnia.md
+++ b/agents/tawnia.md
@@ -1,6 +1,6 @@
 ---
 name: tawnia
-model: haiku
+model: sonnet
 description: Documentation writer - updates docs and makes final commit
 permissionMode: acceptEdits
 skills:


### PR DESCRIPTION
Flips Tawnia's model from `haiku` to `sonnet`.

Tawnia writes documentation (CHANGELOG / README / docs) and makes the **final mission commit** — the last quality gate before a mission lands. `haiku` under-served that role; `sonnet` matches the other write-capable pipeline agents (B.A., Lynch, Amy).

One-line frontmatter change (`agents/tawnia.md`). No release effect (`chore`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Updated the Tawnia agent to use the Sonnet model for improved response capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->