### PR TITLE
feat(write-prd): executive summary + Definition of Done in every PRD

### DIFF
--- a/agents/__tests__/observer-hooks-config.test.ts
+++ b/agents/__tests__/observer-hooks-config.test.ts
@@ -196,18 +196,37 @@ describe('Observer Hooks Configuration', () => {
       });
     });
 
-    it('working agents should retain enforce-completion-log.js hook', () => {
-      const workingAgents = ['murdock.md', 'ba.md', 'lynch.md', 'amy.md', 'tawnia.md'];
+    // Every working agent must block its own stop until agentStop has been
+    // called — but the four pipeline agents enforce a strict superset. In
+    // 1f143ce their Stop hook was deliberately swapped from
+    // enforce-completion-log.js to enforce-handoff.js, which requires BOTH
+    // agentStop AND the peer-to-peer handoff message. Asserting the old hook
+    // on them would demand redundant enforcement of a condition
+    // enforce-handoff.js already covers.
+    it('pipeline agents should retain enforce-handoff.js hook', () => {
+      const pipelineAgents = ['murdock.md', 'ba.md', 'lynch.md', 'amy.md'];
 
-      workingAgents.forEach(agentFile => {
+      pipelineAgents.forEach(agentFile => {
         const frontmatter = extractFrontmatter(join(AGENTS_DIR, agentFile));
         const section = extractHookSection(frontmatter!, 'Stop');
 
         expect(
-          sectionContainsScript(section, 'enforce-completion-log.js'),
-          `${agentFile} should have enforce-completion-log.js`
+          sectionContainsScript(section, 'enforce-handoff.js'),
+          `${agentFile} should have enforce-handoff.js`
         ).toBe(true);
       });
+    });
+
+    // Tawnia is terminal — she makes the final commit and hands off to nobody —
+    // so she keeps plain completion-log enforcement.
+    it('tawnia.md should retain enforce-completion-log.js hook', () => {
+      const frontmatter = extractFrontmatter(join(AGENTS_DIR, 'tawnia.md'));
+      const section = extractHookSection(frontmatter!, 'Stop');
+
+      expect(
+        sectionContainsScript(section, 'enforce-completion-log.js'),
+        'tawnia.md should have enforce-completion-log.js'
+      ).toBe(true);
     });
 
     it('amy.md should retain block-amy-test-writes.js hook', () => {

--- a/agents/murdock.md
+++ b/agents/murdock.md
@@ -66,7 +66,7 @@ You are Murdock, the A(i)-Team's slightly unhinged pilot who sees patterns other
 
 ## Model
 
-opus — test design quality is the load-bearing step for the rest of the pipeline.
+sonnet
 
 ## Tools
 

--- a/agents/murdock.md
+++ b/agents/murdock.md
@@ -1,6 +1,12 @@
 ---
 name: murdock
-model: opus
+# sonnet since 2026-08-10 (was opus). A promptdiff A/B of opus-5 vs sonnet-5 on
+# the in-flight-cancel test gap (WI-207/WI-208, 5 runs/arm) found no quality
+# difference — both arms 0/5 on both scenarios — at ~1.9x the cost ($5.12 vs
+# $2.70). Murdock was also the most expensive agent in M-20260703-001 ($26.09 of
+# $97.23). Caveat: both arms scored zero, so this is a floor result — it shows
+# opus bought nothing on that gap, not that the models are equivalent generally.
+model: sonnet
 effort: low
 description: QA Engineer - writes tests before implementation
 permissionMode: acceptEdits

--- a/agents/murdock.md
+++ b/agents/murdock.md
@@ -7,7 +7,10 @@ name: murdock
 # $97.23). Caveat: both arms scored zero, so this is a floor result — it shows
 # opus bought nothing on that gap, not that the models are equivalent generally.
 model: sonnet
-effort: low
+# raised low -> high with the model change: test design is the reasoning-heavy
+# part of Murdock's job (deriving edge cases the ACs don't spell out), so buy
+# thinking on the cheaper model rather than stacking two reductions at once.
+effort: high
 description: QA Engineer - writes tests before implementation
 permissionMode: acceptEdits
 skills:

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -210,6 +210,8 @@ Agent(
   - Warnings (should fix)
   - Human answers received
   - Specific update instructions for Face
+  - ADR Candidates (MANDATORY section — per your definition §13, always
+    include it; if nothing qualifies write exactly 'ADR Candidates: none.')
 
   Here is the original PRD for context:
 
@@ -266,8 +268,12 @@ SendMessage(
   1. Run ateam deps-check checkDeps --json to get the readyItems list
   2. Move items with NO dependencies to ready stage using ateam board-move moveItem
   3. Leave items WITH dependencies in briefings stage
+  4. Record ADRs: if Sosa's report has a non-empty 'ADR Candidates' section,
+     write each as adr/NNNN-*.md in the target repo per your ADR Recording
+     procedure (Glob for the next number, Write the file). State the ADR
+     outcome explicitly — files written, or exactly 'ADR Candidates: none.'
 
-  Report what was updated and moved."
+  Report what was updated and moved, including the ADR outcome."
 )
 ```
 
@@ -282,10 +288,14 @@ Agent(
 
   **THIS IS THE SECOND PASS.** Apply Sosa's refinements.
 
-  **IMPORTANT: USE MCP TOOLS ONLY.**
-  - DO NOT use Glob, Grep, or Search tools
-  - DO NOT explore any codebase or directories
-  - All information you need is in Sosa's report below
+  **IMPORTANT: USE MCP TOOLS ONLY — one exception, ADR recording.**
+  - DO NOT use Grep or Search tools, and DO NOT explore any codebase or
+    directories to refine items — all information you need for that is in
+    Sosa's report below
+  - The ONLY permitted file access is ADR recording: if Sosa's report has a
+    non-empty 'ADR Candidates' section, you MAY Glob('adr/*.md') to find the
+    next number and Write the adr/NNNN-*.md files (per your ADR Recording
+    procedure). This is the single carve-out to the no-Glob/no-Write rule.
 
   Here is Sosa's refinement report:
 
@@ -299,8 +309,12 @@ Agent(
   1. Run ateam deps-check checkDeps --json to get the readyItems list
   2. Move items with NO dependencies to ready stage using ateam board-move moveItem
   3. Leave items WITH dependencies in briefings stage
+  4. Record ADRs: if Sosa's report has a non-empty 'ADR Candidates' section,
+     write each as adr/NNNN-*.md per your ADR Recording procedure (the Glob/
+     Write carve-out above). State the ADR outcome explicitly — files
+     written, or exactly 'ADR Candidates: none.'
 
-  Report what was updated and moved."
+  Report what was updated and moved, including the ADR outcome."
 )
 ```
 

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -268,7 +268,9 @@ SendMessage(
   1. Run ateam deps-check checkDeps --json to get the readyItems list
   2. Move items with NO dependencies to ready stage using ateam board-move moveItem
   3. Leave items WITH dependencies in briefings stage
-  4. Record ADRs: if Sosa's report has a non-empty 'ADR Candidates' section,
+  4. Record ADRs: if Sosa's 'ADR Candidates' section is anything other than
+     exactly 'ADR Candidates: none.' (the section is ALWAYS present, so its
+     mere existence is not the signal — the sentinel is),
      write each as adr/NNNN-*.md in the target repo per your ADR Recording
      procedure (Glob for the next number, Write the file). State the ADR
      outcome explicitly — files written, or exactly 'ADR Candidates: none.'
@@ -292,10 +294,12 @@ Agent(
   - DO NOT use Grep or Search tools, and DO NOT explore any codebase or
     directories to refine items — all information you need for that is in
     Sosa's report below
-  - The ONLY permitted file access is ADR recording: if Sosa's report has a
-    non-empty 'ADR Candidates' section, you MAY Glob('adr/*.md') to find the
-    next number and Write the adr/NNNN-*.md files (per your ADR Recording
-    procedure). This is the single carve-out to the no-Glob/no-Write rule.
+  - The ONLY permitted file access is ADR recording: if Sosa's 'ADR Candidates'
+    section is anything other than exactly 'ADR Candidates: none.' (the section
+    is ALWAYS present, so its mere existence is not the signal — the sentinel
+    is), you MAY Glob('adr/*.md') to find the next number and Write the
+    adr/NNNN-*.md files (per your ADR Recording procedure). This is the single
+    carve-out to the no-Glob/no-Write rule.
 
   Here is Sosa's refinement report:
 
@@ -309,7 +313,9 @@ Agent(
   1. Run ateam deps-check checkDeps --json to get the readyItems list
   2. Move items with NO dependencies to ready stage using ateam board-move moveItem
   3. Leave items WITH dependencies in briefings stage
-  4. Record ADRs: if Sosa's report has a non-empty 'ADR Candidates' section,
+  4. Record ADRs: if Sosa's 'ADR Candidates' section is anything other than
+     exactly 'ADR Candidates: none.' (the section is ALWAYS present, so its
+     mere existence is not the signal — the sentinel is),
      write each as adr/NNNN-*.md per your ADR Recording procedure (the Glob/
      Write carve-out above). State the ADR outcome explicitly — files
      written, or exactly 'ADR Candidates: none.'

--- a/skills/test-writing/SKILL.md
+++ b/skills/test-writing/SKILL.md
@@ -842,7 +842,7 @@ it('drops repeated submits while a request is in flight', async () => {
 });
 ```
 
-**Repeating the action is only half of it — also test the OPPOSING action during the same in-flight window.** A guard that drops repeat submits does nothing about the user who *cancels* mid-flight. Whenever an async action can be started, ask what else the UI still lets the user do before it settles — cancel, Escape, dismiss, close the dialog, navigate away — and test that path too. The failure is silent and specific: the abandoned action's promise still settles and applies its result, re-applying work the user believed they had discarded (or discarding work they believed they had kept).
+**Repeating the action is only half of it — also test the OPPOSING action during the same in-flight window.** A guard that drops repeat submits does nothing about the user who *cancels* mid-flight. Whenever an async action can be started, ask what else the UI still lets the user do before it settles — cancel, Escape, dismiss, abort, close the dialog, navigate away — and test that path too. The failure is silent and specific: the abandoned action's promise still settles and applies its result, re-applying work the user believed they had discarded (or discarding work they believed they had kept).
 
 Test it by holding the promise unresolved, performing the opposing action, and only THEN settling it:
 
@@ -850,18 +850,23 @@ Test it by holding the promise unresolved, performing the opposing action, and o
 // GOOD: cancelling during an in-flight save must not reapply the result
 it('does not reapply the edit when Cancel is clicked while the save is in flight', async () => {
   let resolveSave!: (t: Todo) => void;
-  vi.mocked(updateTodo).mockReturnValue(new Promise((r) => { resolveSave = r; }));
+  // mockImplementation, not mockReturnValue: each call gets its own promise.
+  vi.mocked(updateTodo).mockImplementation(
+    () => new Promise((resolve) => { resolveSave = resolve; }),
+  );
   render(<TodoItem todo={todo} onChanged={onChanged} {...rest} />);
   await user.click(screen.getByRole('button', { name: /edit/i }));
   await user.type(screen.getByRole('textbox'), 'Abandoned edit');
   await user.keyboard('{Enter}');                                  // save now in flight
+  // Prove the save actually started, or the assertion below passes vacuously.
+  await waitFor(() => expect(updateTodo).toHaveBeenCalledTimes(1));
   await user.click(screen.getByRole('button', { name: /cancel/i })); // opposing action
   resolveSave({ ...todo, title: 'Abandoned edit' });               // settles AFTER the cancel
   await waitFor(() => expect(onChanged).not.toHaveBeenCalled());
 });
 ```
 
-**Each opposing control is its own test.** The guard usually lives on one control — a Cancel button — while the sibling paths (the Escape key, the close affordance, unmounting) stay unprotected. Cover each separately. And when a component gains a *second* async action later (a delete alongside an edit), the opposing-action test does not carry over: apply the same pair to the new action rather than assuming the existing guard generalizes.
+**Each opposing control is its own test.** The guard usually lives on one control — a Cancel button — while the sibling paths (the Escape key, an explicit abort, the close affordance, unmounting) stay unprotected. Cover each separately. And when a component gains a *second* async action later (a delete alongside an edit), the opposing-action test does not carry over: apply the same pair to the new action rather than assuming the existing guard generalizes.
 
 ### Verify exposed props/state are actually consumed
 

--- a/skills/test-writing/SKILL.md
+++ b/skills/test-writing/SKILL.md
@@ -583,7 +583,7 @@ After mapping each acceptance criterion 1:1 to a test, scan for AC *combinations
 
 **Example:** AC-A says "submits via Enter key" and AC-B says "submit disabled during in-flight request." Each has a test individually. But the *combination* — "Enter key blocked during in-flight" — is a distinct scenario that neither test covers alone. If you have tests for A and B individually but not A×B, add the combined test.
 
-**How to check:** After your 1:1 reconciliation pass, identify all "trigger" ACs (user actions: click, keypress, form submit) and all "constraint" ACs (guards, validation, disabled states, loading states). For each trigger × constraint pair, ask: "Is there a test that exercises this trigger while the constraint is active?" If not, add one.
+**How to check:** After your 1:1 reconciliation pass, identify all "trigger" ACs (user actions: click, keypress, form submit, and cancel/dismiss/abort) and all "constraint" ACs (guards, validation, disabled states, loading states). For each trigger × constraint pair, ask: "Is there a test that exercises this trigger while the constraint is active?" If not, add one.
 
 This catches the most common review rejection pattern: guards that only protect one interaction path.
 
@@ -841,6 +841,27 @@ it('drops repeated submits while a request is in flight', async () => {
   expect(onSubmit).toHaveBeenCalledTimes(1);
 });
 ```
+
+**Repeating the action is only half of it — also test the OPPOSING action during the same in-flight window.** A guard that drops repeat submits does nothing about the user who *cancels* mid-flight. Whenever an async action can be started, ask what else the UI still lets the user do before it settles — cancel, Escape, dismiss, close the dialog, navigate away — and test that path too. The failure is silent and specific: the abandoned action's promise still settles and applies its result, re-applying work the user believed they had discarded (or discarding work they believed they had kept).
+
+Test it by holding the promise unresolved, performing the opposing action, and only THEN settling it:
+
+```typescript
+// GOOD: cancelling during an in-flight save must not reapply the result
+it('does not reapply the edit when Cancel is clicked while the save is in flight', async () => {
+  let resolveSave!: (t: Todo) => void;
+  vi.mocked(updateTodo).mockReturnValue(new Promise((r) => { resolveSave = r; }));
+  render(<TodoItem todo={todo} onChanged={onChanged} {...rest} />);
+  await user.click(screen.getByRole('button', { name: /edit/i }));
+  await user.type(screen.getByRole('textbox'), 'Abandoned edit');
+  await user.keyboard('{Enter}');                                  // save now in flight
+  await user.click(screen.getByRole('button', { name: /cancel/i })); // opposing action
+  resolveSave({ ...todo, title: 'Abandoned edit' });               // settles AFTER the cancel
+  await waitFor(() => expect(onChanged).not.toHaveBeenCalled());
+});
+```
+
+**Each opposing control is its own test.** The guard usually lives on one control — a Cancel button — while the sibling paths (the Escape key, the close affordance, unmounting) stay unprotected. Cover each separately. And when a component gains a *second* async action later (a delete alongside an edit), the opposing-action test does not carry over: apply the same pair to the new action rather than assuming the existing guard generalizes.
 
 ### Verify exposed props/state are actually consumed
 

--- a/skills/write-prd/SKILL.md
+++ b/skills/write-prd/SKILL.md
@@ -108,8 +108,8 @@ Consult `references/prd-template.md` for the document structure.
 
 After writing the first draft, review it against this checklist:
 
-- Is there an Executive Summary at the top that captures what/who/why in a few sentences?
-- Is there a Definition of Done section directly under it — blank scaffold (pipeline PRD) or filled with observable, user-visible outcomes (standalone PRD)?
+- Does the document open with an unnumbered `## Executive Summary` (that exact heading, not `## 1. Executive Summary`), placed above every numbered section, capturing what/who/why in a few sentences?
+- Does an unnumbered `## Definition of Done` (that exact heading) follow it immediately — still ahead of `## 1.` — blank scaffold (pipeline PRD) or filled with observable, user-visible outcomes (standalone PRD)?
 - Does every requirement have a clear "why"?
 - Are success metrics specific and measurable?
 - Is scope clearly bounded (in/out)?

--- a/skills/write-prd/SKILL.md
+++ b/skills/write-prd/SKILL.md
@@ -84,6 +84,11 @@ Use the template structure from `references/prd-template.md`. Include only the s
 - **Implementation-free** — Describe what, not how (no architecture, no code)
 - **Strategy-level Solution Approach** — If included, keep Solution Approach at a level a product manager would understand. No code, no schemas, no class names.
 
+**Always open with two top-matter sections, in every tier:**
+
+- **Executive Summary** — 2–4 sentences (scaled to tier) directly under the header: what this delivers, for whom, why now. Draft it last but place it first; it is the section the user reviews to confirm you captured their intent.
+- **Definition of Done** — a checklist of user-visible, observable outcomes, placed directly under the Executive Summary. **Scaffold it blank** (empty checkboxes) unless the user is writing a standalone PRD no mission will decompose — in the A(i)-Team flow, Face fills this rollup during planning and the human blesses it at the refinement gate, so an authored list here would just be overwritten. Never phrase items as implementation steps; every item must be confirmable by using the product.
+
 The PRD header should use the feature name only — no PRD number. Include YAML frontmatter with `missionId` set to `~` (null) — Hannibal will populate it when the mission starts:
 
 ```markdown
@@ -103,6 +108,8 @@ Consult `references/prd-template.md` for the document structure.
 
 After writing the first draft, review it against this checklist:
 
+- Is there an Executive Summary at the top that captures what/who/why in a few sentences?
+- Is there a Definition of Done section directly under it — blank scaffold (pipeline PRD) or filled with observable, user-visible outcomes (standalone PRD)?
 - Does every requirement have a clear "why"?
 - Are success metrics specific and measurable?
 - Is scope clearly bounded (in/out)?

--- a/skills/write-prd/references/prd-best-practices.md
+++ b/skills/write-prd/references/prd-best-practices.md
@@ -306,8 +306,8 @@ Captures constraints and dependencies that affect product decisions without pres
 
 Before finalizing a PRD, verify:
 
-- [ ] An Executive Summary at the top captures what, for whom, and why now in 2–4 sentences
-- [ ] A Definition of Done section sits directly under it — blank when a mission will roll it up, or filled with observable, user-visible outcomes for a standalone PRD
+- [ ] The document opens with an unnumbered `## Executive Summary` (that exact heading, not `## 1. Executive Summary`), ahead of every numbered section, capturing what, for whom, and why now in 2–4 sentences
+- [ ] An unnumbered `## Definition of Done` (that exact heading) sits immediately below it and still ahead of `## 1.` — blank when a mission will roll it up, or filled with observable, user-visible outcomes for a standalone PRD
 - [ ] Problem statement names a user and a measurable impact
 - [ ] Context & Background ties to a business goal and explains "why now"
 - [ ] Every success metric has a current baseline and a target

--- a/skills/write-prd/references/prd-best-practices.md
+++ b/skills/write-prd/references/prd-best-practices.md
@@ -306,6 +306,8 @@ Captures constraints and dependencies that affect product decisions without pres
 
 Before finalizing a PRD, verify:
 
+- [ ] An Executive Summary at the top captures what, for whom, and why now in 2–4 sentences
+- [ ] A Definition of Done section sits directly under it — blank when a mission will roll it up, or filled with observable, user-visible outcomes for a standalone PRD
 - [ ] Problem statement names a user and a measurable impact
 - [ ] Context & Background ties to a business goal and explains "why now"
 - [ ] Every success metric has a current baseline and a target

--- a/skills/write-prd/references/prd-template.md
+++ b/skills/write-prd/references/prd-template.md
@@ -12,6 +12,8 @@ Use this structure when creating new PRDs. Scale the depth to the size of the fe
 
 A bug fix PRD with 11 sections is wasted effort. A new product area with only 3 sections is under-specified. Match the template to the work.
 
+**Two sections appear in every tier**, regardless of depth: the **Executive Summary** and the **Definition of Done**. They sit as top-matter above the numbered sections (they are not sections 1–11) because they are what a stakeholder actually reads first. Scale their length to the tier — a couple of sentences for Quick, a short paragraph and a fuller checklist for Deep — but never omit them.
+
 ---
 
 ```markdown
@@ -22,6 +24,20 @@ missionId: ~
 # Feature Name
 
 **Author:** [name]  **Date:** [date]  **Status:** Draft
+
+## Executive Summary
+
+Two to four sentences a stakeholder can skim without reading the rest: what this delivers, for whom, and why now. Write it *last* — it distills the document — but place it *first*, because it is the section most people read and the one the author reviews for intent. Scale to tier: 2–3 sentences for Quick, a short paragraph for Standard/Deep. No implementation detail; this is the "what and why," compressed.
+
+## Definition of Done
+
+The user-visible outcomes that must be true for this work to count as done — written as observable statements ("submitting a bad email shows the error state"), not implementation checkboxes ("validation handler returns 400"). This is the intent check: a reader should be able to confirm each item by using the product, not by reading the code.
+
+Leave this **blank** when the A(i)-Team pipeline will own it — Face rolls the per-item acceptance criteria up into this section during planning, and the human blesses it at the existing refinement gate. Fill it in yourself for a standalone PRD that no mission will decompose.
+
+- [ ]
+- [ ]
+- [ ]
 
 ## 1. Context & Background
 


### PR DESCRIPTION
## What

The `write-prd` skill now opens every generated PRD with two top-matter sections, present in all tiers (Quick/Standard/Deep):

- **Executive Summary** — 2–4 sentences (scaled to tier) directly under the header: what this delivers, for whom, why now. Drafted last, placed first — it's the section the user reviews to confirm intent was captured.
- **Definition of Done** — a checklist of user-visible, observable outcomes, placed directly under the summary. **Scaffolded blank** in the pipeline flow (Face rolls the per-item acceptance criteria into it during planning and the human blesses it at the refinement gate); filled in only for a standalone PRD no mission will decompose.

## Why

Two motivations, both from recent work:
- The **execution-stage PRD (010)** established that the DoD belongs *where the reader actually looks* — under the exec summary — as the two-minute intent check that catches spec mismatch before build. This bakes that placement into every PRD the skill produces.
- A consistent summary-first shape makes PRDs skimmable and gives the *ratify-don't-author* review loop (see the async-intake PRD) a fixed place to land.

## Design choices

- Both sections are **unnumbered top-matter**, not new numbered sections — so sections 1–11 and every tier-guide reference (`Sections 1-6 + 10`, `All 11 sections`) stay intact.
- The DoD is **blank by default** in the A(i)-Team flow rather than author-filled, because an authored list would just be overwritten by Face's rollup.

## Files

- `skills/write-prd/references/prd-template.md` — the two sections + tier-guide note
- `skills/write-prd/SKILL.md` — Step 4 write guidance + Step 5 review checklist
- `skills/write-prd/references/prd-best-practices.md` — two quality-checklist items

Docs/skill-only; no runtime code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * PRD guidance now requires an Executive Summary and Definition of Done in every tier.
  * Added recommendations for tailoring summary length and completion criteria to the PRD type.
  * Added review checklist items to confirm both sections are included.
  * Pipeline-managed PRDs may leave the Definition of Done blank, while standalone PRDs should include observable outcomes.

* **Workflow Improvements**
  * Planning reports now document ADR candidates and outcomes.
  * Updated agent configuration to improve planning efficiency.

* **Testing**
  * Added guidance for testing cancellation, dismissal, and abort actions during asynchronous operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->